### PR TITLE
Fix incorrect instruction url in HashTag widget

### DIFF
--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/Hashtag/src/Hashtag.jsx
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/Hashtag/src/Hashtag.jsx
@@ -50,8 +50,8 @@ class Hashtag extends Widget {
     render() {
         if (this.state.hashTag.length === 0) {
             var url =
-                'https://github.com/wso2/carbon-analytics/blob/master/features/org.wso2.carbon.sp.solutions.feature/' +
-                'org.wso2.carbon.sp.solutions.twitter.analytics.feature/README.md';
+                'https://github.com/wso2/analytics-solutions/blob/master/features/sp-solution-features/' +
+                'org.wso2.analytics.solutions.sp.twitter.analytics.feature/README.md';
             return (
                 <p style={{ textAlign: 'center' }}>
                     For the processing of "Twitter Analytics" please deploy the Siddhi app as per&nbsp;


### PR DESCRIPTION
## Purpose
Instructions URL linked to an incorrect location after moving the solutions to analytics solutions repo. This PR fix the URL.
