### PR TITLE
Changing siddhi file to handle role filtering, fixing an issue in p2 file

### DIFF
--- a/features/is-analytics-feature/org.wso2.analytics.solutions.is.analytics.feature/src/main/resources/p2.inf
+++ b/features/is-analytics-feature/org.wso2.analytics.solutions.is.analytics.feature/src/main/resources/p2.inf
@@ -25,12 +25,12 @@ org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/worker/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/worker/deployment/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/worker/deployment/siddhi-files/);\
-org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.sp.solutions.is.analytics_${feature.version}/siddhi-files/,target:${installFolder}/../../wso2/worker/deployment/siddhi-files/,overwrite:true);\
+org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.analytics.solutions.is.analytics_${feature.version}/siddhi-files/,target:${installFolder}/../../wso2/worker/deployment/siddhi-files/,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/resources/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/resources/dashboards/);\
-org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.sp.solutions.is.analytics_${feature.version}/dashboards/,target:${installFolder}/../../wso2/dashboard/resources/dashboards/,overwrite:true);\
+org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.analytics.solutions.is.analytics_${feature.version}/dashboards/,target:${installFolder}/../../wso2/dashboard/resources/dashboards/,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/);\
@@ -38,4 +38,4 @@ org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/das
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/portal/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/portal/extensions/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/portal/extensions/widgets/);\
-org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.sp.solutions.is.analytics_${feature.version}/widgets/,target:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/portal/extensions/widgets/,overwrite:true);\
+org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.analytics.solutions.is.analytics_${feature.version}/widgets/,target:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/portal/extensions/widgets/,overwrite:true);\

--- a/features/is-analytics-feature/org.wso2.analytics.solutions.is.analytics.feature/src/main/resources/siddhi-files/IS_AUTHENTICATION_COMMON.siddhi
+++ b/features/is-analytics-feature/org.wso2.analytics.solutions.is.analytics.feature/src/main/resources/siddhi-files/IS_AUTHENTICATION_COMMON.siddhi
@@ -104,7 +104,7 @@ select
     rememberMeEnabled, 
     forceAuthEnabled, 
     passiveAuthEnabled, 
-    rolesCommaSeparated, 
+    str:concat(',', rolesCommaSeparated, ',') as rolesCommaSeparated,
     authenticationStep, 
     identityProvider,
     authenticationSuccess,
@@ -115,6 +115,7 @@ select
     _timestamp as timestamp
 insert into OverallAuthenticationProcessedStream;
 
+-- Adding commas to the start and the end of roles comma separated as to use 'contains' keyword on it.
 from OverallAuthenticationProcessedStream
 select 
     meta_tenantId,
@@ -123,7 +124,7 @@ select
     localUsername, 
     userStoreDomain,
     tenantDomain,
-    rolesCommaSeparated,
+    str:concat(',', rolesCommaSeparated, ',') as rolesCommaSeparated,
     remoteIp,
     region,
     inboundAuthType,


### PR DESCRIPTION
## Purpose
> Siddhi file has changed to handle role filtering in the widgets. To do so, `rolesCommaSeparated` string should have commas on the beginning and the end.
> Fixed an issue with the `p2.inf` file. Where the copy operation failed due to path mismatch.