### PR TITLE
Removing redundant logic from widgets

### DIFF
--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsByType/src/IsAnalyticsAttemptsByType.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsByType/src/IsAnalyticsAttemptsByType.jsx
@@ -255,18 +255,10 @@ class IsAnalyticsAttemptsByType extends Widget {
             if (message.body === '') {
                 this.setState({
                     additionalFilterConditions: undefined,
-                    successData: [],
-                    failureData: [],
-                    currentSuccessDataSet: [],
-                    currentFailureDataSet: [],
                 }, this.assembleQuery);
             } else {
                 this.setState({
                     additionalFilterConditions: message.body,
-                    successData: [],
-                    failureData: [],
-                    currentSuccessDataSet: [],
-                    currentFailureDataSet: [],
                 }, this.assembleQuery);
             }
         } else {
@@ -274,10 +266,6 @@ class IsAnalyticsAttemptsByType extends Widget {
                 per: message.granularity,
                 fromDate: message.from,
                 toDate: message.to,
-                successData: [],
-                failureData: [],
-                currentSuccessDataSet: [],
-                currentFailureDataSet: [],
             }, () => {
                 this.assembleQuery();
             });

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsOverTime/src/IsAnalyticsAttemptsOverTime.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsOverTime/src/IsAnalyticsAttemptsOverTime.jsx
@@ -116,12 +116,10 @@ class IsAnalyticsAttemptsOverTime extends Widget {
             if (message.body === '') {
                 this.setState({
                     additionalFilterConditions: undefined,
-                    data: [],
                 }, this.assembleQuery);
             } else {
                 this.setState({
                     additionalFilterConditions: message.body,
-                    data: [],
                 }, this.assembleQuery);
             }
         } else {
@@ -129,7 +127,6 @@ class IsAnalyticsAttemptsOverTime extends Widget {
                 per: message.granularity,
                 fromDate: message.from,
                 toDate: message.to,
-                data: [],
             }, this.assembleQuery);
         }
     }

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsCompactSummary/src/IsAnalyticsCompactSummary.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsCompactSummary/src/IsAnalyticsCompactSummary.jsx
@@ -139,8 +139,6 @@ class IsAnalyticsCompactSummary extends Widget {
             .toFixed(2);
 
         this.setState({
-            pieChartMetadata,
-            numChartMetadata,
             pieChartData: [
                 [
                     'Failure',
@@ -170,8 +168,6 @@ class IsAnalyticsCompactSummary extends Widget {
             if (message.body === '') {
                 this.setState({
                     additionalFilterConditions: undefined,
-                    pieChartData: [],
-                    numChartData,
                     successPercentage: 0,
                     failurePercentage: 0,
                     totalAttempts: 0,
@@ -179,8 +175,6 @@ class IsAnalyticsCompactSummary extends Widget {
             } else {
                 this.setState({
                     additionalFilterConditions: message.body,
-                    pieChartData: [],
-                    numChartData,
                     successPercentage: 0,
                     failurePercentage: 0,
                     totalAttempts: 0,
@@ -191,8 +185,6 @@ class IsAnalyticsCompactSummary extends Widget {
                 per: message.granularity,
                 fromDate: message.from,
                 toDate: message.to,
-                pieChartData: [],
-                numChartData,
                 successPercentage: 0,
                 failurePercentage: 0,
                 totalAttempts: 0,

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsLoginAttemptsMap/src/IsAnalyticsLoginAttemptsMap.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsLoginAttemptsMap/src/IsAnalyticsLoginAttemptsMap.jsx
@@ -153,12 +153,10 @@ class IsAnalyticsLoginAttemptsMap extends Widget {
             if (message.body === '') {
                 this.setState({
                     additionalFilterConditions: undefined,
-                    data: [],
                 }, () => this.assembleQuery());
             } else {
                 this.setState({
                     additionalFilterConditions: message.body,
-                    data: [],
                 }, () => this.assembleQuery());
             }
         } else {
@@ -166,7 +164,6 @@ class IsAnalyticsLoginAttemptsMap extends Widget {
                 per: message.granularity,
                 fromDate: message.from,
                 toDate: message.to,
-                data: [],
             }, () => this.assembleQuery());
         }
     }
@@ -265,7 +262,6 @@ class IsAnalyticsLoginAttemptsMap extends Widget {
             isFailureMap,
             chartConfig: chartConfigClone,
             switchLabel,
-            data: [],
         }, () => this.assembleQuery());
     }
 

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/package-lock.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/package-lock.json
@@ -6263,9 +6263,9 @@
       }
     },
     "react-tooltip": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.6.1.tgz",
-      "integrity": "sha512-4NVjHNIx1ZazFYBNP044DHW0cr95Qaq0DSwWbrEQ7VyE8AxemHDjp0DoYvV8wilK9vR9jMlSwDW6ebRgbk3aHw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.8.0.tgz",
+      "integrity": "sha512-Uj/vVd0uGuqwTkWeRjKS56T2iwOSvsSMbjqTK7AseHZEMND+WCXXUajaF7+ZsJWTZgnpeT9kBnaBFhchzeDTbw==",
       "requires": {
         "classnames": "^2.2.5",
         "prop-types": "^15.6.0"
@@ -6283,9 +6283,9 @@
       }
     },
     "react-vizgrammar": {
-      "version": "0.7.23",
-      "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.23.tgz",
-      "integrity": "sha512-YXRDpi/QhRTiLsAn7zBRCAn7wtXbobmLpDWmuyONeCn1Aovc1yo5/QlTbSKRLJDhynUZc5Hmfq/0UnDhOXQb3Q==",
+      "version": "0.7.27",
+      "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.27.tgz",
+      "integrity": "sha512-B69sjX0XS8NXkjiLJCUExroluxPMkE/CdSYeBocQMZ/QCK+/veW66bFX3nDszWpvI0z8e2jOxuG2lOCB94x++A==",
       "requires": {
         "d3": "^4.12.0",
         "lodash": "^4.17.4",

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/package.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/package.json
@@ -9,7 +9,7 @@
     "moment": "^2.22.2",
     "react": "^16.4.1",
     "react-custom-scrollbars": "^4.2.1",
-    "react-vizgrammar": "^0.7.22",
+    "react-vizgrammar": "^0.7.27",
     "rimraf": "^2.6.2",
     "style-loader": "^0.21.0"
   },

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/src/IsAnalyticsMessages.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/src/IsAnalyticsMessages.jsx
@@ -69,7 +69,8 @@ const metadataOverall = {
 };
 
 const metadataLocal = {
-    names: ['contextId',
+    names: [
+        'contextId',
         'username',
         'serviceProvider',
         'userStoreDomain',
@@ -153,8 +154,7 @@ const columnsOverall = [
     {
         name: 'authSuccess',
         title: 'Overall Authentication',
-        colorBasedStyle: true,
-        colorScale: boolColorScale,
+        highlight: true,
     },
     {
         name: 'utcTime',
@@ -198,8 +198,7 @@ const columnsLocal = [
     {
         name: 'authSuccess',
         title: 'Local Authentication',
-        colorBasedStyle: true,
-        colorScale: boolColorScale,
+        highlight: true,
     },
     {
         name: 'utcTime',
@@ -235,14 +234,23 @@ const columnsFederated = [
     {
         name: 'authSuccess',
         title: 'Authentication Step Success',
-        colorBasedStyle: true,
-        colorScale: boolColorScale,
+        highlight: true,
     },
     {
         name: 'utcTime',
         title: 'Timestamp',
     },
 ];
+
+function getStyle (state, rowInfo) {
+    if (rowInfo && rowInfo.row.authSuccess === 'Success') {
+        return colorGreen;
+    } else if (rowInfo && rowInfo.row.authSuccess === 'Failure') {
+        return colorRed;
+    } else {
+        return null;
+    }
+}
 
 const tableConfig = {
     charts: [
@@ -253,6 +261,13 @@ const tableConfig = {
     pagination: true,
     filterable: true,
     append: false,
+    dataFunction: (state, rowInfo) => {
+        return {
+            style: {
+                background: getStyle(state, rowInfo),
+            },
+        };
+    },
 };
 
 class IsAnalyticsMessages extends Widget {

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/src/IsAnalyticsMessages.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/src/IsAnalyticsMessages.jsx
@@ -326,19 +326,16 @@ class IsAnalyticsMessages extends Widget {
             if (message.body === '') {
                 this.setState({
                     additionalFilterConditions: undefined,
-                    data: [],
                 }, this.assembleQuery);
             } else {
                 this.setState({
                     additionalFilterConditions: message.body,
-                    data: [],
                 }, this.assembleQuery);
             }
         } else {
             this.setState({
                 fromDate: message.from,
                 toDate: message.to,
-                data: [],
             }, this.assembleQuery);
         }
     }

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSummary/src/IsAnalyticsSummary.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSummary/src/IsAnalyticsSummary.jsx
@@ -264,7 +264,7 @@ class IsAnalyticsSummary extends Widget {
                         </Typography>
                     </div>
                     <div style={{
-                        height: height * 0.1,
+                        height: height * 0.15,
                         width: width * 0.9,
                     }}
                     >

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSummary/src/IsAnalyticsSummary.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSummary/src/IsAnalyticsSummary.jsx
@@ -155,10 +155,10 @@ class IsAnalyticsSummary extends Widget {
 
     handleReceivedData(message) {
         if (message.data.length > 0 && message.data[0] > 0) {
-            const totalAttempts = parseInt(message.data[0][0]) + parseInt(message.data[0][1]);
-            const successPercentage = parseFloat(parseInt(message.data[0][1]) * 100 / totalAttempts)
+            const totalAttempts = parseInt(message.data[0][0], 10) + parseInt(message.data[0][1]);
+            const successPercentage = parseFloat(parseInt(message.data[0][1], 10) * 100 / totalAttempts)
                 .toFixed(2);
-            const failurePercentage = parseFloat(parseInt(message.data[0][0]) * 100 / totalAttempts)
+            const failurePercentage = parseFloat(parseInt(message.data[0][0], 10) * 100 / totalAttempts)
                 .toFixed(2);
 
             this.setState({
@@ -193,8 +193,6 @@ class IsAnalyticsSummary extends Widget {
             per: message.granularity,
             fromDate: message.from,
             toDate: message.to,
-            pieChartData: [],
-            numChartData: [[0], [0]],
             totalAttempts: 0,
             successPercentage: 0,
             failurePercentage: 0,

--- a/features/is-analytics-feature/org.wso2.analytics.solutions.is.analytics.feature/src/main/resources/dashboards/is-analytics.json
+++ b/features/is-analytics-feature/org.wso2.analytics.solutions.is.analytics.feature/src/main/resources/dashboards/is-analytics.json
@@ -950,7 +950,7 @@
                         },
                         "isGenerated": false,
                         "options": {
-                          "widgetType": "Overall"
+                          "widgetType": "Local"
                         }
                       },
                       "widgetID": "IsAnalyticsMessages"


### PR DESCRIPTION
## Purpose
> * The call back function of the `WidgetChannelManager` was not worked before, when there are no data coming from the data provider. Now the functionality is fixed and hence the redundant logic is removed which used to reset data in the widget before the data provider call.
> * The `IsAnalyticsMessages` widget in the `Local Login Attempts` page was set to the widget type of `Overall`, mistakenly. It is now fixed.

## Documentation
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
