### PR TITLE
Remove apim widgets and dashboard from apim analytics feature

### DIFF
--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/p2.inf
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/p2.inf
@@ -21,12 +21,6 @@ metaRequirements.0.name = org.wso2.carbon.extensions.touchpoint
 metaRequirements.0.optional = true
 
 instructions.configure = \
-org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/);\
-org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/);\
-org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/portal/);\
-org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/portal/extensions/);\
-org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/portal/extensions/widgets/);\
-org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.analytics.solutions.apim.analytics_${feature.version}/widgets/,target:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/portal/extensions/widgets/,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/resources/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/resources/businessRules/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/resources/businessRules/templates/);\
@@ -34,9 +28,6 @@ org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/featur
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/worker/deployment/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/worker/deployment/siddhi-files/);\
 org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.analytics.solutions.apim.analytics_${feature.version}/siddhi-files/,target:${installFolder}/../../wso2/worker/deployment/siddhi-files/,overwrite:true);\
-org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/resources/);\
-org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/resources/dashboards/);\
-org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.analytics.solutions.apim.analytics_${feature.version}/dashboard/,target:${installFolder}/../../wso2/dashboard/resources/dashboards/,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/worker/database/);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../lib/features/org.wso2.analytics.solutions.apim.analytics_${feature.version}/wso2/worker/database/,target:${installFolder}/../../wso2/worker/database/,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../resources/);\


### PR DESCRIPTION
## Purpose
This PR will avoid apim widgets and dashboards getting packed inside the SP distribution.