### PR TITLE
Change widget titles to IS Analytics ... Instead os Is Analytics ...

### DIFF
--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsByType/src/resources/widgetConf.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsByType/src/resources/widgetConf.json
@@ -1,5 +1,5 @@
 {
-  "name": "Is Analytics Attempts By Type",
+  "name": "IS Analytics Attempts By Type",
   "id": "IsAnalyticsAttemptsByType",
   "thumbnailURL": "",
   "configs": {
@@ -46,16 +46,10 @@
         "id": "headerTitle",
         "title": "Widget Display Name",
         "type": {
-          "name": "ENUM",
-          "possibleValues": [
-            "Login Attempts By Service Provider",
-            "Login Attempts By User Store Domain",
-            "Login Attempts By Role",
-            "Login Attempts By Identity Provider",
-            "Login Attempts By Username"
-          ]
+          "name": "TEXT",
+          "possibleValues": []
         },
-        "defaultValue": "Login Attempts By Username"
+        "defaultValue": "Login Attempts By "
       }
     ],
     "providerConfig": {

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsOverTime/src/resources/widgetConf.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsOverTime/src/resources/widgetConf.json
@@ -1,5 +1,5 @@
 {
-  "name": "Is Analytics Attempts Over Time",
+  "name": "IS Analytics Attempts Over Time",
   "id": "IsAnalyticsAttemptsOverTime",
   "thumbnailURL": "",
   "configs": {
@@ -26,14 +26,10 @@
         "id": "headerTitle",
         "title": "Widget Display Name",
         "type": {
-          "name": "Enum",
-          "possibleValues": [
-            "Overall Login Attempts Over Time",
-            "Local Login Attempts Over Time",
-            "Federated Login Attempts Over Time"
-          ]
+          "name": "TEXT",
+          "possibleValues": []
         },
-        "defaultValue": "Overall Login Attempts Over Time"
+        "defaultValue": "Login Attempts Over Time"
       }
     ],
     "providerConfig": {

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsCompactSummary/src/resources/widgetConf.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsCompactSummary/src/resources/widgetConf.json
@@ -1,5 +1,5 @@
 {
-  "name": "Is Analytics Compact Summary",
+  "name": "IS Analytics Compact Summary",
   "id": "IsAnalyticsCompactSummary",
   "thumbnailURL": "",
   "configs": {
@@ -26,14 +26,10 @@
         "id": "headerTitle",
         "title": "Widget Display Name",
         "type": {
-          "name": "ENUM",
-          "possibleValues": [
-            "Overall Login Attempts Compact Summary",
-            "Local Login Attempts Compact Summary",
-            "Federated Login Attempts Compact Summary"
-          ]
+          "name": "TEXT",
+          "possibleValues": []
         },
-        "defaultValue": "Overall Login Attempts Compact Summary"
+        "defaultValue": "Login Attempts Compact Summary"
       }
     ],
     "providerConfig": {

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsLoginAttemptsMap/src/resources/widgetConf.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsLoginAttemptsMap/src/resources/widgetConf.json
@@ -1,5 +1,5 @@
 {
-  "name": "Is Analytics Login Attempts Map",
+  "name": "IS Analytics Login Attempts Map",
   "id": "IsAnalyticsLoginAttemptsMap",
   "thumbnailURL": "",
   "configs": {
@@ -26,14 +26,10 @@
         "id": "headerTitle",
         "title": "Widget Display Name",
         "type": {
-          "name": "ENUM",
-          "possibleValues": [
-            "Overall Login Attempts Map",
-            "Local Login Attempts Map",
-            "Federated Login Attempts Map"
-          ]
+          "name": "TEXT",
+          "possibleValues": []
         },
-        "defaultValue": "Overall Login Attempts Map"
+        "defaultValue": "Login Attempts Map"
       }
     ],
     "providerConfig": {

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/src/resources/widgetConf.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/src/resources/widgetConf.json
@@ -1,5 +1,5 @@
 {
-  "name": "Is Analytics Messages",
+  "name": "IS Analytics Messages",
   "id": "IsAnalyticsMessages",
   "thumbnailURL": "",
   "configs": {
@@ -26,14 +26,10 @@
         "id": "headerTitle",
         "title": "Widget Display Name",
         "type": {
-          "name": "ENUM",
-          "possibleValues": [
-            "Overall Login Attempts Messages",
-            "Local Login Attempts Messages",
-            "Federated Login Attempts Messages"
-          ]
+          "name": "TEXT",
+          "possibleValues": []
         },
-        "defaultValue": "Overall Login Attempts Messages"
+        "defaultValue": "Login Attempts Messages"
       }
     ],
     "providerConfig": {

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSummary/src/resources/widgetConf.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSummary/src/resources/widgetConf.json
@@ -26,14 +26,10 @@
         "id": "headerTitle",
         "title": "Widget Display Name",
         "type": {
-          "name": "ENUM",
-          "possibleValues": [
-            "Overall Login Attempts Summary",
-            "Local Login Attempts Summary",
-            "Federated Login Attempts Summary"
-          ]
+          "name": "TEXT",
+          "possibleValues": []
         },
-        "defaultValue": "Overall Login Attempts Summary"
+        "defaultValue": "Login Attempts Summary"
       }
     ],
     "providerConfig": {

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsUserPreferences/src/resources/widgetConf.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsUserPreferences/src/resources/widgetConf.json
@@ -1,5 +1,5 @@
 {
-  "name": "Is Analytics User Preferences",
+  "name": "IS Analytics User Preferences",
   "id": "IsAnalyticsUserPreferences",
   "thumbnailURL": "",
   "configs": {
@@ -31,14 +31,10 @@
         "id": "headerTitle",
         "title": "Widget Display Name",
         "type": {
-          "name": "ENUM",
-          "possibleValues": [
-            "Overall Login Attempts User Preferences",
-            "Local Login Attempts User Preferences",
-            "Federated Login Attempts User Preferences"
-          ]
+          "name": "TEXT",
+          "possibleValues": []
         },
-        "defaultValue": "Overall Login User Preferences"
+        "defaultValue": "User Preferences"
       }
     ]
   }


### PR DESCRIPTION
## Purpose
> Fixes #116 for the following widgets
> * IS Analytics Attempts By Type
> * IS Analytics Attempts Over Time
> * IS Analytics Compact Summary
> * IS Analytics Messages
> * IS Analytics Login Attempts Map
> * IS Analytics Summary
> * IS Analytics User Preferences
>
> Change the type of custom titles of widgets to `TEXT` from `ENUM`