### PR TITLE
Bump material-ui version in User Preferences

### DIFF
--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsLoginAttemptsMap/src/IsAnalyticsLoginAttemptsMap.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsLoginAttemptsMap/src/IsAnalyticsLoginAttemptsMap.jsx
@@ -80,7 +80,7 @@ let classCounter = 0;
 
 // This is not the default export
 // eslint-disable-next-line import/prefer-default-export
-export const generateClassName = (rule, styleSheet) => {
+export const LoginAttemptsMapStylesClass = (rule, styleSheet) => {
     classCounter += 1;
 
     if (process.env.NODE_ENV === 'production') {
@@ -287,7 +287,7 @@ class IsAnalyticsLoginAttemptsMap extends Widget {
 
         if (this.state.isDataProviderConfigFault) {
             return (
-                <JssProvider generateClassName={generateClassName}>
+                <JssProvider generateClassName={LoginAttemptsMapStylesClass}>
                     <MuiThemeProvider theme={theme}>
                         <div style={divSpacings}>
                             <Typography variant="body1" gutterBottom align="center">
@@ -300,7 +300,7 @@ class IsAnalyticsLoginAttemptsMap extends Widget {
             );
         }
         return (
-            <JssProvider generateClassName={generateClassName}>
+            <JssProvider generateClassName={LoginAttemptsMapStylesClass}>
                 <MuiThemeProvider theme={theme}>
                     <div style={divSpacings}>
                         <div style={{ height: height * 0.6, width: width * 0.9 }}>

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsUserPreferences/package-lock.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsUserPreferences/package-lock.json
@@ -737,11 +737,11 @@
       }
     },
     "@material-ui/core": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-1.5.1.tgz",
-      "integrity": "sha512-hGT0JelWZGZqgWZzRbON/uqFCgWa4XhmEFG/IEd9SBwCU4sWC99Kv1KpywLhYYWecobqT4Dh7ijO1ZaIAk8HyA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-beqrCT2QTw+R9DLc+V2W2GGr/jU87L2eVTrL1kU2qfnkRz+LwJHL6YCyh0gUFgZig4ywDCIQiaMMs0/3rU3qDw==",
       "requires": {
-        "@babel/runtime": "7.0.0-rc.1",
+        "@babel/runtime": "7.0.0-beta.42",
         "@types/jss": "9.5.4",
         "@types/react-transition-group": "2.0.13",
         "brcast": "3.0.1",
@@ -768,6 +768,27 @@
         "react-transition-group": "2.4.0",
         "recompose": "0.28.2",
         "warning": "4.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.0.0-beta.42",
+          "resolved": "http://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.42.tgz",
+          "integrity": "sha512-iOGRzUoONLOtmCvjUsZv3mZzgCT6ljHQY5fr1qG1QIiJQwtM7zbPWGGpa3QWETq+UqwWyJnoi5XZDZRwZDFciQ==",
+          "requires": {
+            "core-js": "2.5.7",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
       }
     },
     "@types/jss": {

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsUserPreferences/package.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsUserPreferences/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@material-ui/core": "^1.5.1",
+    "@material-ui/core": "^1.5.0",
     "@wso2-dashboards/widget": "^1.4.0",
     "css-loader": "^0.28.11",
     "react": "^16.4.0",

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsUserPreferences/src/IsAnalyticsUserPreferences.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsUserPreferences/src/IsAnalyticsUserPreferences.jsx
@@ -83,7 +83,7 @@ const escapeRegex = /([[\].#*$><+~=|^:(),"'`\s])/g;
 let classCounter = 0;
 
 // eslint-disable-next-line import/prefer-default-export
-export const generateClassName = (rule, styleSheet) => {
+export const userPreferencesStylesClass = (rule, styleSheet) => {
     classCounter += 1;
 
     if (process.env.NODE_ENV === 'production') {
@@ -254,7 +254,7 @@ class IsAnalyticsUserPreferences extends Widget {
         }
 
         return (
-            <JssProvider generateClassName={generateClassName}>
+            <JssProvider generateClassName={userPreferencesStylesClass}>
                 <MuiThemeProvider theme={theme}>
                     <div style={divSpacings}>
                         <div style={{ height: height * 0.6, width: width * 0.9 }}>


### PR DESCRIPTION
## Purpose
> Bump `material-ui` version to `1.5.0` in `IS Analytics User Preferences` widget
> Changing the styles class name to overcome ambiguity.

## Documentation
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
