### PR TITLE
Change the AnalyticsSpan time generator granularity

### DIFF
--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.message.tracer/components/open-tracer-client/org.wso2.sp.open.tracer.client/src/main/java/org/wso2/sp/open/tracer/client/AnalyticsSpan.java
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.message.tracer/components/open-tracer-client/org.wso2.sp.open.tracer.client/src/main/java/org/wso2/sp/open/tracer/client/AnalyticsSpan.java
@@ -279,7 +279,8 @@ final class AnalyticsSpan implements Span {
     }
 
     static long nowMicros() {
-        return System.nanoTime();
+        //todo: revert the time generator to nowMicros(), after fixing the Siddhi microsecond support
+        return System.currentTimeMillis();
     }
 
     private synchronized void finishedCheck(String format, Object... args) {


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to fix the AnalyticsSpan time generator granularity as nanosecond currently not supported by the Siddhi and Widgets. Hence the widget time ranges shown incorrect time/period values.  This change can be reverted after adding proper fixes for support nanosecond in Siddhi and SP Open tracing solution widgets.

## Goals
> Change the AnalyticsSpan time generator granularity, will resolve the problems described above.

## Approach
> Change the timing generator from nanoTime() to currentTimeMillis()

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A


## Certification
> N/A


## Marketing
> N/A


## Automation tests
 - Unit tests 
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 1.8
 
## Learning
> N/A