### PR TITLE
Removing widget height and width assignment from the outer div

### DIFF
--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsByType/src/IsAnalyticsAttemptsByType.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsByType/src/IsAnalyticsAttemptsByType.jsx
@@ -403,8 +403,8 @@ class IsAnalyticsAttemptsByType extends Widget {
             paddingRight: width * 0.05,
             paddingTop: height * 0.05,
             paddingBottom: height * 0.05,
-            height,
-            width,
+            display: 'flex',
+            'flex-direction': 'column',
         };
 
         let theme = darkTheme;

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsOverTime/src/IsAnalyticsAttemptsOverTime.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsOverTime/src/IsAnalyticsAttemptsOverTime.jsx
@@ -197,8 +197,8 @@ class IsAnalyticsAttemptsOverTime extends Widget {
             paddingRight: width * 0.05,
             paddingTop: height * 0.05,
             paddingBottom: height * 0.05,
-            height,
-            width,
+            display: 'flex',
+            'flex-direction': 'column',
         };
         let theme = darkTheme;
 

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsCompactSummary/src/IsAnalyticsCompactSummary.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsCompactSummary/src/IsAnalyticsCompactSummary.jsx
@@ -248,8 +248,8 @@ class IsAnalyticsCompactSummary extends Widget {
             paddingRight: width * 0.05,
             paddingTop: height * 0.05,
             paddingBottom: height * 0.05,
-            height,
-            width,
+            display: 'flex',
+            'flex-direction': 'column',
         };
         let theme = darkTheme;
 

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsLoginAttemptsMap/src/IsAnalyticsLoginAttemptsMap.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsLoginAttemptsMap/src/IsAnalyticsLoginAttemptsMap.jsx
@@ -251,8 +251,8 @@ class IsAnalyticsLoginAttemptsMap extends Widget {
             paddingRight: width * 0.05,
             paddingTop: height * 0.05,
             paddingBottom: height * 0.05,
-            height: '100%',
-            width: '100%',
+            display: 'flex',
+            'flex-direction': 'column',
         };
 
         if (this.state.isDataProviderConfigFault) {

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/src/IsAnalyticsMessages.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/src/IsAnalyticsMessages.jsx
@@ -417,8 +417,8 @@ class IsAnalyticsMessages extends Widget {
             paddingRight: width * 0.02,
             paddingTop: height * 0.02,
             paddingBottom: height * 0.02,
-            height,
-            width,
+            display: 'flex',
+            'flex-direction': 'column',
         };
         let theme = darkTheme;
 

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSummary/src/IsAnalyticsSummary.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSummary/src/IsAnalyticsSummary.jsx
@@ -235,8 +235,8 @@ class IsAnalyticsSummary extends Widget {
             paddingRight: width * 0.05,
             paddingTop: height * 0.05,
             paddingBottom: height * 0.05,
-            height,
-            width,
+            display: 'flex',
+            'flex-direction': 'column',
         };
         let theme = darkTheme;
 

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsUserPreferences/src/IsAnalyticsUserPreferences.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsUserPreferences/src/IsAnalyticsUserPreferences.jsx
@@ -244,8 +244,8 @@ class IsAnalyticsUserPreferences extends Widget {
             paddingRight: width * 0.05,
             paddingTop: height * 0.05,
             paddingBottom: height * 0.05,
-            height,
-            width,
+            display: 'flex',
+            'flex-direction': 'column',
         };
         let theme = darkTheme;
 


### PR DESCRIPTION
## Purpose
> Removing `height` and `width` assignments in the outer `div`'s of all the widgets and replace them with `display: 'flex'` attribute.
> `'flex-direction': 'column'` is used as the default `direction` is `row`.

## Documentation
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes