### PR TITLE
Disable same start timestamp and end timestamp for custom range selector

### DIFF
--- a/components/analytics-solutions-common/org.wso2.analytics.solutions.common/widgets/DateTimeRangePicker/src/CustomTimeRangeSelector.jsx
+++ b/components/analytics-solutions-common/org.wso2.analytics.solutions.common/widgets/DateTimeRangePicker/src/CustomTimeRangeSelector.jsx
@@ -102,9 +102,8 @@ export default class CustomTimeRangeSelector extends React.Component {
 
     handleStartTimeChange(date) {
         this.startTime = date;
-        const start = Moment(this.startTime);
-        const end = Moment(this.endTime);
-        if(end.diff(start) < 0) {
+        if(Moment(this.startTime,'YYYY-MM-DD HH:mm:ss.000').unix() >=
+            Moment(this.endTime,'YYYY-MM-DD HH:mm:ss.000').unix()) {
             this.setState({ invalidDateRange: true });
         } else {
             this.setState({ invalidDateRange: false });
@@ -113,9 +112,8 @@ export default class CustomTimeRangeSelector extends React.Component {
 
     handleEndTimeChange(date) {
         this.endTime = date;
-        const start = Moment(this.startTime);
-        const end = Moment(this.endTime);
-        if(end.diff(start) < 0) {
+        if(Moment(this.startTime,'YYYY-MM-DD HH:mm:ss.000').unix() >=
+            Moment(this.endTime,'YYYY-MM-DD HH:mm:ss.000').unix()) {
             this.setState({ invalidDateRange: true });
         } else {
             this.setState({ invalidDateRange: false });
@@ -173,6 +171,7 @@ export default class CustomTimeRangeSelector extends React.Component {
                             onChange={this.handleStartTimeChange}
                             inputType={inputType}
                             theme={theme}
+                            initTime = {Moment().subtract(1, 'days')}
                         />
                     </div>
                     <div
@@ -187,6 +186,7 @@ export default class CustomTimeRangeSelector extends React.Component {
                             onChange={this.handleEndTimeChange}
                             inputType={inputType}
                             theme={theme}
+                            initTime = {Moment()}
                         />
                     </div>
                 </div>

--- a/components/analytics-solutions-common/org.wso2.analytics.solutions.common/widgets/DateTimeRangePicker/src/CustomTimeRangeSelector.jsx
+++ b/components/analytics-solutions-common/org.wso2.analytics.solutions.common/widgets/DateTimeRangePicker/src/CustomTimeRangeSelector.jsx
@@ -31,7 +31,7 @@ export default class CustomTimeRangeSelector extends React.Component {
             invalidDateRange: false
         };
 
-        this.startTime = new Date();
+        this.startTime = Moment().subtract(1, 'days').toDate();
         this.endTime = new Date();
         this.handleStartTimeChange = this.handleStartTimeChange.bind(this);
         this.handleEndTimeChange = this.handleEndTimeChange.bind(this);

--- a/components/analytics-solutions-common/org.wso2.analytics.solutions.common/widgets/DateTimeRangePicker/src/DateTimePicker.jsx
+++ b/components/analytics-solutions-common/org.wso2.analytics.solutions.common/widgets/DateTimeRangePicker/src/DateTimePicker.jsx
@@ -25,10 +25,10 @@ export default class DateTimePicker extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            year: new Date().getFullYear(),
-            month: new Date().getMonth(),
-            days: new Date().getDate(),
-            time: moment().format('HH:mm:ss.SSS'),
+            year: this.props.initTime.year(),
+            month: this.props.initTime.month(),
+            days: this.props.initTime.date(),
+            time: this.props.initTime.format('HH:mm:ss.000'),
         };
 
         this.generateDays = this.generateDays.bind(this);
@@ -132,7 +132,7 @@ export default class DateTimePicker extends React.Component {
 
         state[property] = value;
         const date = moment(`${state.year}:${(state.month + 1)}:${state.days} ${state.time}`,
-            'YYYY-MM-DD HH:mm:ss.SSS').toDate();
+            'YYYY-MM-DD HH:mm:ss.000').toDate();
 
         switch (inputType) {
             case 'year':


### PR DESCRIPTION
## Purpose
Disable selection of equal start and end timestamps in custom time range selector and set the start and end times with difference of 1 day as default values.

**Note: please review, do not merge**