### PR TITLE
Remove defined executions for pre-clean & clean phases in exec-maven-plugin

### DIFF
--- a/components/analytics-solutions-common/org.wso2.analytics.solutions.common/widgets/DateTimeRangePicker/pom.xml
+++ b/components/analytics-solutions-common/org.wso2.analytics.solutions.common/widgets/DateTimeRangePicker/pom.xml
@@ -57,6 +57,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/apim-analytics/org.wso2.analytics.solutions.apim.analytics/widgets/APIMApiCreatorAlertConfiguration/pom.xml
+++ b/components/apim-analytics/org.wso2.analytics.solutions.apim.analytics/widgets/APIMApiCreatorAlertConfiguration/pom.xml
@@ -54,6 +54,10 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/components/apim-analytics/org.wso2.analytics.solutions.apim.analytics/widgets/APIMApiSubscriberAlertConfiguration/pom.xml
+++ b/components/apim-analytics/org.wso2.analytics.solutions.apim.analytics/widgets/APIMApiSubscriberAlertConfiguration/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsHorizontalBarChart/pom.xml
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsHorizontalBarChart/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMediatorProperties/pom.xml
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMediatorProperties/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageFlow/pom.xml
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageFlow/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageTable/pom.xml
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageTable/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsSearchBox/pom.xml
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsSearchBox/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsStatsChart/pom.xml
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsStatsChart/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsTPS/pom.xml
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsTPS/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsByType/pom.xml
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsByType/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsOverTime/pom.xml
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAttemptsOverTime/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAverageSessionDuration/pom.xml
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAverageSessionDuration/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsCompactSummary/pom.xml
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsCompactSummary/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsLoginAttemptsMap/pom.xml
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsLoginAttemptsMap/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/pom.xml
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsMessages/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSessionCount/pom.xml
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSessionCount/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSessionCountOverTime/pom.xml
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSessionCountOverTime/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSessionMessages/pom.xml
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSessionMessages/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSummary/pom.xml
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSummary/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsTopLongestSession/pom.xml
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsTopLongestSession/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsUserPreferences/pom.xml
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsUserPreferences/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsLatencyComparison/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsLatencyComparison/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsLatencyOverTime/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsLatencyOverTime/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsRequestCountComparison/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsRequestCountComparison/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsRequestCountFilter/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsRequestCountFilter/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsRequestCountOverTime/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsRequestCountOverTime/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsRequestStatistics/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsRequestStatistics/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsResponseCodeFilter/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.http.analytics/widgets/HTTPAnalyticsResponseCodeFilter/pom.xml
@@ -54,6 +54,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.message.tracer/widgets/OpenTracingList/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.message.tracer/widgets/OpenTracingList/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.message.tracer/widgets/OpenTracingSearch/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.message.tracer/widgets/OpenTracingSearch/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.message.tracer/widgets/OpenTracingVisTimeline/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.message.tracer/widgets/OpenTracingVisTimeline/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/Emotions/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/Emotions/pom.xml
@@ -56,6 +56,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/EmotionsAnalysis/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/EmotionsAnalysis/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/Hashtag/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/Hashtag/pom.xml
@@ -56,6 +56,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/LiveTweets/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/LiveTweets/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/PopularTweets/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/PopularTweets/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/TopCountries/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/TopCountries/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/TopSentiment/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/TopSentiment/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/TweetCountAnalysis/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/TweetCountAnalysis/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/TweetCounter/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/TweetCounter/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/WordCloud/pom.xml
+++ b/components/sp-solutions/org.wso2.analytics.solutions.sp.twitter.analytics/widgets/WordCloud/pom.xml
@@ -55,6 +55,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -811,8 +811,6 @@
         <carbon.feature.plugin.version>3.1.3</carbon.feature.plugin.version>
         <maven.exec.plugin.version>1.5.0</maven.exec.plugin.version>
         <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>
-        <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>
-        <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>
 
         <testng.version>6.9.4</testng.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.wso2</groupId>
@@ -236,14 +237,16 @@
 
             <dependency>
                 <groupId>org.wso2.analytics.solutions</groupId>
-                <artifactId>org.wso2.analytics.solutions.apim.analytics.widgets.apim.apisubscriber.alert.config</artifactId>
+                <artifactId>org.wso2.analytics.solutions.apim.analytics.widgets.apim.apisubscriber.alert.config
+                </artifactId>
                 <version>${project.version}</version>
                 <type>zip</type>
             </dependency>
 
             <dependency>
                 <groupId>org.wso2.analytics.solutions</groupId>
-                <artifactId>org.wso2.analytics.solutions.apim.analytics.widgets.apim.apicreator.alert.config</artifactId>
+                <artifactId>org.wso2.analytics.solutions.apim.analytics.widgets.apim.apicreator.alert.config
+                </artifactId>
                 <version>${project.version}</version>
                 <type>zip</type>
             </dependency>
@@ -284,7 +287,8 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.analytics.solutions</groupId>
-                <artifactId>org.wso2.analytics.solutions.sp.http.analytics.widgets.server.request.count.comparison</artifactId>
+                <artifactId>org.wso2.analytics.solutions.sp.http.analytics.widgets.server.request.count.comparison
+                </artifactId>
                 <version>${project.version}</version>
                 <type>zip</type>
             </dependency>
@@ -328,7 +332,8 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.analytics.solutions</groupId>
-                <artifactId>org.wso2.analytics.solutions.sp.message.tracer.widgets.open-tracing-vis-timeline</artifactId>
+                <artifactId>org.wso2.analytics.solutions.sp.message.tracer.widgets.open-tracing-vis-timeline
+                </artifactId>
                 <version>${project.version}</version>
                 <type>zip</type>
             </dependency>
@@ -594,6 +599,20 @@
                     <version>${maven.src.version}</version>
                 </plugin>
                 <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven.clean.plugin.version}</version>
+                    <configuration>
+                        <filesets>
+                            <fileset>
+                                <directory>${project.basedir}/node_modules</directory>
+                            </fileset>
+                            <fileset>
+                                <directory>${project.basedir}/dist</directory>
+                            </fileset>
+                        </filesets>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>${maven.exec.plugin.version}</version>
@@ -608,36 +627,6 @@
                                 <executable>${npm.executable}</executable>
                                 <arguments>
                                     <argument>install</argument>
-                                </arguments>
-                            </configuration>
-                        </execution>
-                        <!-- 'npm run clean' which is run in clean lifecycle needs 'rimraf' node module.
-                         Make sure it is installed  -->
-                        <execution>
-                            <id>npm install rimraf (clean)</id>
-                            <goals>
-                                <goal>exec</goal>
-                            </goals>
-                            <phase>pre-clean</phase>
-                            <configuration>
-                                <executable>${npm.executable}</executable>
-                                <arguments>
-                                    <argument>install</argument>
-                                    <argument>rimraf</argument>
-                                </arguments>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>npm run clean (clean)</id>
-                            <goals>
-                                <goal>exec</goal>
-                            </goals>
-                            <phase>clean</phase>
-                            <configuration>
-                                <executable>${npm.executable}</executable>
-                                <arguments>
-                                    <argument>run</argument>
-                                    <argument>clean</argument>
                                 </arguments>
                             </configuration>
                         </execution>
@@ -821,6 +810,9 @@
         <org.jacoco.version>0.7.9</org.jacoco.version>
         <carbon.feature.plugin.version>3.1.3</carbon.feature.plugin.version>
         <maven.exec.plugin.version>1.5.0</maven.exec.plugin.version>
+        <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>
+        <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>
+        <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>
 
         <testng.version>6.9.4</testng.version>
     </properties>


### PR DESCRIPTION
## Purpose
$subject. The same improvement that was done for carbon-dashboards repository.

## Goals
- Reduce build time of `analytics-solutions` repo.

## Approach
- Removed `npm install rimraf (clean)` and `npm run clean (clean)` executions from `exec-maven-plugin` in root `pom.xml`.
- Instead used `maven-clean-plugin` to delete `dist` & `node_modules` directories in the `clean` phase.

## Automation tests
Ran local builds for a freshly cloned `carbon-dashboards` repo.

|                               | Before      | After   	     |
|------------------------- |-------------- |-------------- |
| `mvn clean`           | 18:26 min | 5.079 s     |
| `mvn clean install` | 39:43 min | 23:36 min |        

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Test environment
- Maven v3.5.4
 