### PR TITLE
Improving EI analytics siddhi app

### DIFF
--- a/features/ei-analytics-feature/org.wso2.analytics.solutions.ei.analytics.feature/src/main/resources/siddhi-files/EI_Analytics_StatApp.siddhi
+++ b/features/ei-analytics-feature/org.wso2.analytics.solutions.ei.analytics.feature/src/main/resources/siddhi-files/EI_Analytics_StatApp.siddhi
@@ -40,11 +40,16 @@ define stream ConfigEntryEventStream (meta_tenantId int, hashcode string, entryN
 -- defines the DecompressedEventStream, which stores decompressed FlowEntryEventStream data
 define stream DecompressedEventStream (metaTenantId int, messageFlowId string, host string, hashCode string, componentName string, componentType string, componentIndex int, componentId string, startTime long, endTime long, duration long, beforePayload string, afterPayload string, contextPropertyMap string, transportPropertyMap string, children string, entryPoint string, entryPointHashcode string, faultCount int, eventTimestamp long);
 
+-- defines the TableInsertAsyncStream, which inserts events asynchronously into ESBEventTable
+@Async(buffer.size = '8192', workers = '4', batch.size.max = '2000')
+define stream ESBEventTableInsertAsyncStream (metaTenantId int, messageFlowId string, host string, hashCode string,
+componentName string, componentType string, componentIndex int, componentId string, startTime long, endTime long, duration long, beforePayload string, afterPayload string, contextPropertyMap string, transportPropertyMap string, children string, entryPoint string, entryPointHashcode string, faultCount int, eventTimestamp long);
+
 -- Tables
 
 -- table that stores ESBEventStream data
 @store(type = 'rdbms', datasource = 'EI_ANALYTICS', field.length="contextPropertyMap:5000,beforePayload:5000,afterPayload:5000,transportPropertyMap:5000" )
-@Index('metaTenantId','messageFlowId','host','hashCode','componentName','componentType','componentIndex','componentId','startTime','endTime','entryPoint','entryPointHashcode','faultCount')
+@Index('metaTenantId','messageFlowId')
 define table ESBEventTable (metaTenantId int, messageFlowId string, host string, hashCode string, componentName string, componentType string, componentIndex int, componentId string, startTime long, endTime long, duration long, beforePayload string, afterPayload string, contextPropertyMap string, transportPropertyMap string, children string, entryPoint string, entryPointHashcode string, faultCount int, eventTimestamp long);
 
 -- table that stores ConfigEntryEventStream data
@@ -101,9 +106,13 @@ from DecompressedEventStream[not((ComponentNameTable.componentId == componentId)
 select componentId, componentName, componentType
 insert into ComponentNameTable;
 
--- if DecompressedEventStream has beforePayload or transportPropertyMap or contextPropertyMap, add them to into ESBEventTable
+-- if DecompressedEventStream has beforePayload or transportPropertyMap or contextPropertyMap, add them to into ESBEventTable through an async stream
 from DecompressedEventStream[not(beforePayload is null) or not(transportPropertyMap is null) or not(contextPropertyMap is null)]
 select metaTenantId, messageFlowId, host, hashCode, componentName, componentType, componentIndex, componentId, startTime, endTime, duration, beforePayload, afterPayload, contextPropertyMap, transportPropertyMap, children, entryPoint, entryPointHashcode, faultCount, eventTimestamp
+insert current events into ESBEventTableInsertAsyncStream;
+
+from ESBEventTableInsertAsyncStream
+select *
 insert current events into ESBEventTable;
 
 -- if DecompressedEventStream's componentType is ProxyService or API or InboundEndPoint, add it into PreProcessedESBStatStream


### PR DESCRIPTION
## Purpose
Improves the throughput of EI Analytics SIddhi app.

## Approach
A low throughput was observed for the table insert query for ESBEventTable. Using @Async annotation improves the throughput to some extent.
Only two indexes are required for the ESBEventTable, which also improves the throughput.
