### PR TITLE
[HTTP-Analytics-Solution] Make Default HTTP source URL constant for better user experience

### DIFF
--- a/features/sp-solution-features/org.wso2.analytics.solutions.sp.http.analytics.feature/src/main/resources/templates/http-analytics-solution.json
+++ b/features/sp-solution-features/org.wso2.analytics.solutions.sp.http.analytics.feature/src/main/resources/templates/http-analytics-solution.json
@@ -20,7 +20,7 @@
                "RequestsStreamSource": {
                   "fieldName": "Source Requests Stream Source",
                   "description": "Source definition for Requests Stream to receive request events",
-                  "defaultValue": "type='http', @map(type='json')"
+                  "defaultValue": "type='http', receiver.url='http://localhost:8280/HttpAnalytics/RequestsStream' , @map(type='json')"
                },
                "HTTPAnalyticsStore": {
                   "fieldName": "Store for HTTP Analytics",


### PR DESCRIPTION
## Purpose
To fix CURL commands in try-out tutorial dynamic. As default HTTP source does not include receiver.url param, this makes the HTTP source defined to have a URL based on business rules name deployed. Thus Documentation has CURL commands which the user has to edit before using.
Fixes https://github.com/wso2/analytics-solutions/issues/211

## Goals
By defining a constant URL, the final CURL commands can be given, thus giving better user experience.

## Approach
Define receiver.url param in default source definition.
`type='http', receiver.url='http://localhost:8280/HttpAnalytics/RequestsStream' , @map(type='json')
`

## Documentation
https://docs.wso2.com/display/SP4xx/HTTP+Analytics needs to be updated with new CURL commands,
Sample:
`curl -v -X POST \  http://localhost:8280/HttpAnalytics/RequestsStream \  -H 'content-type: application/json' \  -d '{  "event": {    "timestamp": 1528795987,    "serverName": "localhost",    "serviceName": "A",    "serviceMethod": "GET",    "responseTime": 1000.00,    "httpResponseCode": 200,    "userAgent": "Mozilla/5.0 (iPad; U; CPU OS 3_2_1 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Mobile/7B405",    "requestIP": "127.0.0.1"  }}'
`

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
