### PR TITLE
[EIAnalytics] [Mediator Request Count] Fix mediator name overlapping the next div

### DIFF
--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsStatsChart/src/EIAnalyticsStatsChart.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsStatsChart/src/EIAnalyticsStatsChart.jsx
@@ -278,7 +278,7 @@ class EIAnalyticsStatsChart extends Widget {
                     justifyContent: 'center'
                 }}>
                     <h2><b>Total</b> requests</h2>
-                    <h4><span
+                    <h4 title={this.state.componentName} style={{overflow: 'hidden', textOverflow: 'ellipsis'}}><span
                         id="title">{this.state.componentName != null ? 'for ' + this.state.componentName : null}</span>
                     </h4>
                     <h1 id="totalCount">{this.state.totalCount}</h1>


### PR DESCRIPTION
## Purpose
> Fix #160 Mediator name overlaps the chart

## Goals
> Add css to handle the overlapping
> Add a tooltip with full name of the component

## Screenshots

Before
![a1](https://user-images.githubusercontent.com/32201965/53869646-9dabf680-401e-11e9-9853-09485e24f1bb.png)

After
![a2](https://user-images.githubusercontent.com/32201965/53869652-a3a1d780-401e-11e9-92a6-ff853471d3bf.png)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes