### PR TITLE
[EIAnalytics] [MediatorProperties] Check for payload before drawing the MergeView

### DIFF
--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMediatorProperties/src/EIAnalyticsMediatorProperties.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMediatorProperties/src/EIAnalyticsMediatorProperties.jsx
@@ -264,7 +264,9 @@ class EIAnalyticsMediatorProperties extends Widget {
 
     generateMergedView() {
         const data = this.state.messageComparisonData;
-        drawMergeView(this.domElementPayloadView, data.payload.before.trim(), data.payload.after.trim());
+        if (data.payload.before && data.payload.after) {
+            drawMergeView(this.domElementPayloadView, data.payload.before.trim(), data.payload.after.trim());
+        }
 
         if (data.transportProperties) {
             let transportPropertiesBefore = '';


### PR DESCRIPTION
## Purpose
> Fix issue #223 Screen goes blank if payload.before and payload.after are undefined

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes