### PR TITLE
Fix id e3 not in scope issue

### DIFF
--- a/features/is-analytics-feature/org.wso2.analytics.solutions.is.analytics.feature/src/main/resources/siddhi-files/IS_ANALYTICS_SUSPICIOUS_LOGIN.siddhi
+++ b/features/is-analytics-feature/org.wso2.analytics.solutions.is.analytics.feature/src/main/resources/siddhi-files/IS_ANALYTICS_SUSPICIOUS_LOGIN.siddhi
@@ -137,7 +137,7 @@ select  meta_tenantId,
         UUID() as alertId,
         "SuspiciousLoginAlert" as type,
         tenantDomain,
-        str:concat('Successful login attempt after multiple login failures from same username: ', username, ' detected at: ', time:dateFormat(e3[last].timestamp,'yyyy-MM-dd HH:mm:ss'), '.') as msg,
+        str:concat('Successful login attempt after multiple login failures from same username: ', username, ' detected at: ', time:dateFormat(timestamp,'yyyy-MM-dd HH:mm:ss'), '.') as msg,
         severity,
         (time:timestampInMilliseconds()) as alertTimestamp,
         time:dateFormat((time:timestampInMilliseconds()),'yyyy-MM-dd HH:mm:ss') as userReadableTime


### PR DESCRIPTION
## Purpose
> Fix Id 'e3' not defined within scope issue 

## Goals
> To deploy IS_ANALYTICS_SUSPICIOUS_LOGIN.siddhi app without any error in IS Analytics

## Approach
> Defined the relevant field within the given scope

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> java version "1.8.0_191"
   mysql version "5.7.25"
   mysql-connector-java-8.0.12
