### PR TITLE
[EIAnalytics] [MessageTableWidget] Add scrollbar for the table

### DIFF
--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageTable/src/EIAnalyticsMessageTable.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageTable/src/EIAnalyticsMessageTable.jsx
@@ -18,6 +18,7 @@
 
 import Widget from "@wso2-dashboards/widget";
 import VizG from 'react-vizgrammar';
+import {Scrollbars} from 'react-custom-scrollbars';
 import {darkBaseTheme, getMuiTheme, MuiThemeProvider} from 'material-ui/styles';
 import moment from 'moment';
 
@@ -209,6 +210,7 @@ class EIAnalyticsMessageTable extends Widget {
     render() {
         return (
             <MuiThemeProvider muiTheme={getMuiTheme(darkBaseTheme)}>
+                <Scrollbars style={{width: "100%"}}>
                 <section style={{paddingTop: 50}}>
                     <VizG
                         config={this.chartConfig}
@@ -220,6 +222,7 @@ class EIAnalyticsMessageTable extends Widget {
                         onClick={this.handleRowSelect}
                     />
                 </section>
+                </Scrollbars>
             </MuiThemeProvider>
         );
     }


### PR DESCRIPTION
## Purpose
> Fix issue #227 Message table is not visible when no of rows per page are set more than 5.

## Approach
> Add a scrollbar for the table.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes