### PR TITLE
[EIAnalytics] [Widgets] Bump react-vizgrammar version

### DIFF
--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsHorizontalBarChart/package.json
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsHorizontalBarChart/package.json
@@ -11,7 +11,7 @@
     "eslint-plugin-react": "^7.11.1",
     "moment": "^2.22.2",
     "react": "^16.4.1",
-    "react-vizgrammar": "^0.8.4",
+    "react-vizgrammar": "^0.8.5",
     "rimraf": "^2.6.2",
     "style-loader": "^0.21.0"
   },

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsStatsChart/package.json
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsStatsChart/package.json
@@ -10,7 +10,7 @@
     "react-container-dimensions": "^1.3.4",
     "react-custom-scrollbars": "^4.2.1",
     "react-dom": "^16.1.1",
-    "react-vizgrammar": "^0.8.4",
+    "react-vizgrammar": "^0.8.5",
     "rimraf": "^2.6.2",
     "style-loader": "^0.21.0"
   },

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsTPS/package.json
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsTPS/package.json
@@ -7,7 +7,7 @@
     "css-loader": "^1.0.0",
     "moment": "^2.22.2",
     "react": "^16.4.1",
-    "react-vizgrammar": "^0.8.4",
+    "react-vizgrammar": "^0.8.5",
     "rimraf": "^2.6.2",
     "style-loader": "^0.21.0"
   },


### PR DESCRIPTION
## Purpose
> Bump react-vizgrammar to latest version V0.8.5 in EIAnalytics Widgets

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes