### PR TITLE
[EIAnalytics] Get tenantId from dashboard properties instead of hardcoded constants

### DIFF
--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsHorizontalBarChart/src/EIAnalyticsHorizontalBarChart.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsHorizontalBarChart/src/EIAnalyticsHorizontalBarChart.jsx
@@ -25,7 +25,6 @@ const BAR_GRAPH_TYPE = 'Component Type Selection';
 const URL_PARAMETER_ID = 'id';
 const DIV_ID_GRAPH = 'graph';
 const PUBLISHER_DATE_TIME_PICKER = 'granularity';
-const TENANT_ID = '-1234';
 
 /**
  * Dashboard widget class for the EIAnalyticsHorizontalBarChart widget

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsHorizontalBarChart/src/EIAnalyticsHorizontalBarChart.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsHorizontalBarChart/src/EIAnalyticsHorizontalBarChart.jsx
@@ -134,7 +134,7 @@ class EIAnalyticsHorizontalBarChart extends Widget {
                 dataProviderConf.configs.config.queryData.query = query
                     .replace('{{aggregator}}', aggregator)
                     .replace('{{componentType}}', graphType)
-                    .replace('{{tenantId}}', TENANT_ID)
+                    .replace('{{tenantId}}', this.props.dashboard.properties.tenantId)
                     .replace('{{timeFrom}}', this.state.timeFromParameter)
                     .replace('{{timeTo}}', this.state.timeToParameter)
                     .replace('{{timeUnit}}', this.state.timeUnitParameter);

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMediatorProperties/src/EIAnalyticsMediatorProperties.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMediatorProperties/src/EIAnalyticsMediatorProperties.jsx
@@ -34,7 +34,6 @@ import './codemirror.css';
 import './merge.css';
 import './nanoscroller.css';
 
-const META_TENANT_ID = '-1234';
 const centerDiv = {
     textAlign: 'center',
     verticalAlign: 'middle',

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMediatorProperties/src/EIAnalyticsMediatorProperties.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMediatorProperties/src/EIAnalyticsMediatorProperties.jsx
@@ -91,7 +91,7 @@ class EIAnalyticsMediatorProperties extends Widget {
                             const formattedQuery = query
                                 .replace('{{messageFlowId}}', messageFlowId)
                                 .replace('{{componentId}}', componentId)
-                                .replace('{{meta_tenantId}}', META_TENANT_ID);
+                                .replace('{{meta_tenantId}}', this.props.dashboard.properties.tenantId);
                             dataProviderConf.configs.config.queryData = {query: formattedQuery};
                             // Request data store with the modified query
                             super.getWidgetChannelManager()
@@ -125,7 +125,7 @@ class EIAnalyticsMediatorProperties extends Widget {
                         const formattedQuery = query
                             .replace('{{messageFlowId}}', messageFlowId)
                             .replace('{{componentIndex}}', childIndex)
-                            .replace('{{meta_tenantId}}', META_TENANT_ID);
+                            .replace('{{meta_tenantId}}', this.props.dashboard.properties.tenantId);
                         dataProviderConf.configs.config.queryData = {query: formattedQuery};
                         // Request data store with the modified query
                         super.getWidgetChannelManager()

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageFlow/src/EIAnalyticsMessageFlow.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageFlow/src/EIAnalyticsMessageFlow.jsx
@@ -1179,7 +1179,7 @@ class EIAnalyticsMessageFlow extends Widget {
             let entry = super.getGlobalState(getKey("message", "id"));
             this.drawMessageFlowGraph(
                 entry,
-                DEFAULT_META_TENANT_ID
+                this.props.dashboard.properties.tenantId
             );
         }
     }

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageFlow/src/EIAnalyticsMessageFlow.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageFlow/src/EIAnalyticsMessageFlow.jsx
@@ -34,7 +34,6 @@ const TYPE_PROXY = "proxy";
 const TYPE_API = "api";
 const TYPE_INBOUND_ENDPOINT = "inbound";
 const TYPE_MESSAGE = "message";
-const DEFAULT_META_TENANT_ID = '-1234';
 
 let BASE_URL = getDashboardBaseUrl();
 

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageFlow/src/EIAnalyticsMessageFlow.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageFlow/src/EIAnalyticsMessageFlow.jsx
@@ -60,7 +60,7 @@ class EIAnalyticsMessageFlow extends Widget {
             timeTo: null,
             timeUnit: null,
             selectedComponantID: null,
-            meta_tenantId: '-1234',
+            meta_tenantId: props.dashboard.properties.tenantId,
             lastDrawnGraphData: null
         };
         this.handleRecievedMessage = this.handleMessage.bind(this);
@@ -1179,7 +1179,7 @@ class EIAnalyticsMessageFlow extends Widget {
             let entry = super.getGlobalState(getKey("message", "id"));
             this.drawMessageFlowGraph(
                 entry,
-                this.props.dashboard.properties.tenantId
+                this.parameters.meta_tenantId
             );
         }
     }

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageTable/src/EIAnalyticsMessageTable.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageTable/src/EIAnalyticsMessageTable.jsx
@@ -162,7 +162,7 @@ class EIAnalyticsMessageTable extends Widget {
                 dataProviderConf.configs.config.queryData.query = query
                     .replace("{{timeFrom}}", this.state.timeFromParameter)
                     .replace("{{timeTo}}", this.state.timeToParameter)
-                    .replace("{{metaTenantId}}", TENANT_ID)
+                    .replace("{{metaTenantId}}", this.props.dashboard.properties.tenantId)
                     .replace("{{componentType}}", componentType)
                     .replace("{{componentIdentifier}}", componentIdentifier)
                     .replace("{{componentName}}", componentName);

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageTable/src/EIAnalyticsMessageTable.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsMessageTable/src/EIAnalyticsMessageTable.jsx
@@ -22,7 +22,6 @@ import {Scrollbars} from 'react-custom-scrollbars';
 import {darkBaseTheme, getMuiTheme, MuiThemeProvider} from 'material-ui/styles';
 import moment from 'moment';
 
-const TENANT_ID = '-1234';
 const MESSAGE_PAGE = "message";
 
 class EIAnalyticsMessageTable extends Widget {

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsStatsChart/src/EIAnalyticsStatsChart.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsStatsChart/src/EIAnalyticsStatsChart.jsx
@@ -25,7 +25,6 @@ const PAGE_PROXY = 'proxy';
 const PAGE_OVERVIEW = 'overview';
 const PAGE_API = 'api';
 const PAGE_SEQUENCE = 'sequence';
-const TENANT_ID = '-1234';
 const PAGE_ENDPOINT = 'endpoint';
 const PAGE_INBOUND_ENDPOINT = 'inbound';
 const PAGE_MEDIATOR = 'mediator';

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsStatsChart/src/EIAnalyticsStatsChart.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsStatsChart/src/EIAnalyticsStatsChart.jsx
@@ -136,28 +136,28 @@ class EIAnalyticsStatsChart extends Widget {
             else if (this.state.componentName != null) {
                 switch (pageName) {
                     case PAGE_PROXY:
-                        this.extractStatsData(PAGE_PROXY, this.state.componentName, null, TENANT_ID, "ESBStatAgg",
+                        this.extractStatsData(PAGE_PROXY, this.state.componentName, null, this.props.dashboard.properties.tenantId, "ESBStatAgg",
                             this.state.timeFrom, this.state.timeTo, this.state.timeUnit);
                         break;
                     case PAGE_API:
-                        this.extractStatsData(PAGE_API, this.state.componentName, null, TENANT_ID, "ESBStatAgg",
+                        this.extractStatsData(PAGE_API, this.state.componentName, null, this.props.dashboard.properties.tenantId, "ESBStatAgg",
                             this.state.timeFrom, this.state.timeTo, this.state.timeUnit);
                         break;
                     case PAGE_SEQUENCE:
                         this.extractStatsData(PAGE_SEQUENCE, this.state.componentName,
-                            this.state.entryPoint, TENANT_ID, "MediatorStatAgg", this.state.timeFrom, this.state.timeTo, this.state.timeUnit);
+                            this.state.entryPoint, this.props.dashboard.properties.tenantId, "MediatorStatAgg", this.state.timeFrom, this.state.timeTo, this.state.timeUnit);
                         break;
                     case PAGE_ENDPOINT:
                         this.extractStatsData(PAGE_ENDPOINT, this.state.componentName,
-                            this.state.entryPoint, TENANT_ID, "MediatorStatAgg", this.state.timeFrom, this.state.timeTo, this.state.timeUnit);
+                            this.state.entryPoint, this.props.dashboard.properties.tenantId, "MediatorStatAgg", this.state.timeFrom, this.state.timeTo, this.state.timeUnit);
                         break;
                     case PAGE_INBOUND_ENDPOINT:
-                        this.extractStatsData(PAGE_INBOUND_ENDPOINT, this.state.componentName, null, TENANT_ID, "ESBStatAgg",
+                        this.extractStatsData(PAGE_INBOUND_ENDPOINT, this.state.componentName, null, this.props.dashboard.properties.tenantId, "ESBStatAgg",
                             this.state.timeFrom, this.state.timeTo, this.state.timeUnit);
                         break;
                     case PAGE_MEDIATOR:
                         this.extractStatsData(PAGE_MEDIATOR, this.state.componentName,
-                            this.state.entryPoint, TENANT_ID, "MediatorStatAgg", this.state.timeFrom, this.state.timeTo, this.state.timeUnit);
+                            this.state.entryPoint, this.props.dashboard.properties.tenantId, "MediatorStatAgg", this.state.timeFrom, this.state.timeTo, this.state.timeUnit);
                         break;
                 }
             }

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsStatsChart/src/EIAnalyticsStatsChart.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsStatsChart/src/EIAnalyticsStatsChart.jsx
@@ -130,7 +130,7 @@ class EIAnalyticsStatsChart extends Widget {
                 /*
                 componentType, componentName, entryPoint, tenantId, aggregator
                  */
-                this.extractStatsData("ALL", "ALL", null, -1234, "ESBStatAgg", this.state.timeFrom, this.state.timeTo, this.state.timeUnit);
+                this.extractStatsData("ALL", "ALL", null, this.props.dashboard.properties.tenantId, "ESBStatAgg", this.state.timeFrom, this.state.timeTo, this.state.timeUnit);
             }
             else if (this.state.componentName != null) {
                 switch (pageName) {

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsTPS/src/EIAnalyticsTPS.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsTPS/src/EIAnalyticsTPS.jsx
@@ -21,7 +21,6 @@ import VizG from 'react-vizgrammar';
 import moment from 'moment';
 
 var PUBLISHER_DATE_TIME_PICKER = 'granularity';
-var TENANT_ID = '-1234';
 
 class EIAnalyticsTPS extends Widget {
     constructor(props) {

--- a/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsTPS/src/EIAnalyticsTPS.jsx
+++ b/components/ei-analytics/org.wso2.analytics.solutions.ei.analytics/widgets/EIAnalyticsTPS/src/EIAnalyticsTPS.jsx
@@ -112,7 +112,7 @@ class EIAnalyticsTPS extends Widget {
 
                 // Insert required parameters to the query string
                 let formattedQuery = query
-                    .replace("{{tenantId}}", TENANT_ID)
+                    .replace("{{tenantId}}", this.props.dashboard.properties.tenantId)
                     .replace("{{timeFrom}}", "\'" + this.state.timeFromParameter + "\'")
                     .replace("{{timeTo}}", "\'" + this.state.timeToParameter + "\'")
                     .replace("{{timeunit}}", "\'" + timeUnit + "\'")

--- a/features/ei-analytics-feature/org.wso2.analytics.solutions.ei.analytics.feature/src/main/resources/dashboards/ei-anlaytics.json
+++ b/features/ei-analytics-feature/org.wso2.analytics.solutions.ei.analytics.feature/src/main/resources/dashboards/ei-anlaytics.json
@@ -6,2462 +6,2467 @@
         "description": "A dashboard to display Enterprise Integrator Analytics",
         "landingPage": "overview",
         "parentId": "0",
-        "pages": [
-            {
-                "id": "overview",
-                "name": "Overview",
-                "content": [
-                    {
-                        "type": "column",
-                        "isClosable": true,
-                        "title": "",
-                        "content": [
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 9.378841171430285,
-                                "width": 100.0,
-                                "content": [
-                                    {
-                                        "title": "Date Time Range",
-                                        "type": "component",
-                                        "component": "DateRangePicker",
-                                        "props": {
-                                            "id": "aa53daba-1042-4a5b-9ebb-d74bf0770f3d",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "publisher"
-                                                    ],
-                                                    "publisherWidgetOutputs": [
-                                                        "granularity",
-                                                        "from",
-                                                        "to"
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-                                                    "defaultValue": "3 Months",
-                                                    "availableGranularities": "From Second",
-                                                    "autoSyncInterval": "10",
-                                                    "header": false
-                                                }
-                                            },
-                                            "widgetID": "DateRangePicker"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 24.714553309646,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Stats Chart",
-                                        "type": "component",
-                                        "component": "EIAnalyticsStatsChart",
-                                        "props": {
-                                            "id": "caa21446-1300-480b-af06-7eef4570414f",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber"
-                                                    ],
-                                                    "publishers": [
-                                                        "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-                                                    "headerTitle": "Request Count"
-                                                }
-                                            },
-                                            "widgetID": "EIAnalyticsStatsChart"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "row",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 20.22629716614896,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "height": 18.668444461415717,
-                                        "width": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "EI Analytics TPS",
-                                                "type": "component",
-                                                "component": "EIAnalyticsTPS",
-                                                "props": {
-                                                    "id": "20ceb84d-a96d-402e-98d3-6845233b4e74",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "publishers": [
-                                                                "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-
-                                                            ]
-                                                        },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "headerTitle": "Overall TPS"
-                                                        }
-                                                    },
-                                                    "widgetID": "EIAnalyticsTPS"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "[Overall Message Count]",
-                                                "type": "component",
-                                                "component": "UniversalWidget",
-                                                "props": {
-                                                    "id": "5df7940c-4cf7-4667-bcbd-8f96d0d904bd",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "subscriberWidgetInputs": [
-                                                                "timeFrom",
-                                                                "timeTo",
-                                                                "timeUnit"
-                                                            ],
-                                                            "publishers": [
-                                                                "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-                                                                {
-                                                                    "subscriberWidgetInput": "timeFrom",
-                                                                    "publisherId": "aa53daba-1042-4a5b-9ebb-d74bf0770f3d",
-                                                                    "publisherWidgetOutput": "from"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeTo",
-                                                                    "publisherId": "aa53daba-1042-4a5b-9ebb-d74bf0770f3d",
-                                                                    "publisherWidgetOutput": "to"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeUnit",
-                                                                    "publisherId": "aa53daba-1042-4a5b-9ebb-d74bf0770f3d",
-                                                                    "publisherWidgetOutput": "granularity"
-                                                                }
-                                                            ]
-                                                        },
-                                                        "isGenerated": true,
-                                                        "options": {
-                                                            "headerTitle": "Overall Message Count"
-                                                        }
-                                                    },
-                                                    "widgetID": "Overall-Message-Count"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "row",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 23.45429404540676,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "height": 25.0,
-                                        "width": 49.92917847025496,
-                                        "content": [
-                                            {
-                                                "title": "EI Analytics Horizontal Bar Chart",
-                                                "type": "component",
-                                                "component": "EIAnalyticsHorizontalBarChart",
-                                                "props": {
-                                                    "id": "1dba552a-d3a1-441f-b7b6-73b552182dda",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "publishers": [
-                                                                "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
-                                                            ]
-                                                        },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "Component Type Selection": "proxy service",
-                                                            "headerTitle": "Top Proxy Services by Request Count"
-                                                        }
-                                                    },
-                                                    "widgetID": "EIAnalyticsHorizontalBarChart"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 50.07082152974505,
-                                        "content": [
-                                            {
-                                                "title": "EI Analytics Horizontal Bar Chart",
-                                                "type": "component",
-                                                "component": "EIAnalyticsHorizontalBarChart",
-                                                "props": {
-                                                    "id": "6b688b47-ef87-4114-90e6-3bd76766459c",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "publishers": [
-                                                                "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
-                                                            ]
-                                                        },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "Component Type Selection": "api",
-                                                            "headerTitle": "Top APIs by Request Count"
-                                                        }
-                                                    },
-                                                    "widgetID": "EIAnalyticsHorizontalBarChart"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "row",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 22.226014307368,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "height": 100.0,
-                                        "width": 29.989094874591057,
-                                        "content": [
-                                            {
-                                                "title": "EI Analytics Horizontal Bar Chart",
-                                                "type": "component",
-                                                "component": "EIAnalyticsHorizontalBarChart",
-                                                "props": {
-                                                    "id": "f95513cb-2d88-4554-9982-8fe9d310c0ee",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "publishers": [
-                                                                "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
-                                                            ]
-                                                        },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "Component Type Selection": "endpoint",
-                                                            "headerTitle": "Top Endpoints by Request Count"
-                                                        }
-                                                    },
-                                                    "widgetID": "EIAnalyticsHorizontalBarChart"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 35.176781902660125,
-                                        "content": [
-                                            {
-                                                "title": "EI Analytics Horizontal Bar Chart",
-                                                "type": "component",
-                                                "component": "EIAnalyticsHorizontalBarChart",
-                                                "props": {
-                                                    "id": "af583379-fa88-412c-8f2f-9a91d11e8e1f",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "publishers": [
-                                                                "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
-                                                            ]
-                                                        },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "Component Type Selection": "sequence",
-                                                            "headerTitle": "Top Sequences by Request Count"
-                                                        }
-                                                    },
-                                                    "widgetID": "EIAnalyticsHorizontalBarChart"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 34.834123222748815,
-                                        "content": [
-                                            {
-                                                "title": "EI Analytics Horizontal Bar Chart",
-                                                "type": "component",
-                                                "component": "EIAnalyticsHorizontalBarChart",
-                                                "props": {
-                                                    "id": "31a90bea-f5b3-4bcc-bf5c-1b7645066233",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "publishers": [
-                                                                "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
-                                                            ]
-                                                        },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "Component Type Selection": "inbound endpoint",
-                                                            "headerTitle": "Top Inbound Endpoints by Request Count"
-                                                        }
-                                                    },
-                                                    "widgetID": "EIAnalyticsHorizontalBarChart"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "height": 1714.0
+        "content": {
+            "properties": {
+                "tenantId": "-1234"
             },
-            {
-                "id": "proxy",
-                "name": "Proxy Services",
-                "content": [
-                    {
-                        "type": "column",
-                        "isClosable": true,
-                        "title": "",
-                        "content": [
-                            {
-                                "type": "row",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 9.906580958757585,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 33.56871758426203,
-                                        "height": 7.849504987941964,
-                                        "content": [
-                                            {
-                                                "title": "EI Analytics Search Box",
-                                                "type": "component",
-                                                "component": "EIAnalyticsSearchBox",
-                                                "props": {
-                                                    "id": "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "publisher"
-                                                            ],
-                                                            "publisherWidgetOutputs": [
-                                                                "selectedComponent"
-                                                            ]
-                                                        },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "header": false
-                                                        }
+            "pages": [
+                {
+                    "id": "overview",
+                    "name": "Overview",
+                    "content": [
+                        {
+                            "type": "column",
+                            "isClosable": true,
+                            "title": "",
+                            "content": [
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 9.378841171430285,
+                                    "width": 100.0,
+                                    "content": [
+                                        {
+                                            "title": "Date Time Range",
+                                            "type": "component",
+                                            "component": "DateRangePicker",
+                                            "props": {
+                                                "id": "aa53daba-1042-4a5b-9ebb-d74bf0770f3d",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "publisher"
+                                                        ],
+                                                        "publisherWidgetOutputs": [
+                                                            "granularity",
+                                                            "from",
+                                                            "to"
+                                                        ]
                                                     },
-                                                    "widgetID": "EIAnalyticsSearchBox"
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "defaultValue": "3 Months",
+                                                        "availableGranularities": "From Second",
+                                                        "autoSyncInterval": "10",
+                                                        "header": false
+                                                    }
                                                 },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 66.431282415738,
-                                        "content": [
-                                            {
-                                                "title": "Date Time Range",
-                                                "type": "component",
-                                                "component": "DateRangePicker",
-                                                "props": {
-                                                    "id": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "publisher"
-                                                            ],
-                                                            "publisherWidgetOutputs": [
-                                                                "granularity",
-                                                                "from",
-                                                                "to"
-                                                            ]
-                                                        },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "defaultValue": "3 Months",
-                                                            "availableGranularities": "From Second",
-                                                            "autoSyncInterval": "10",
-                                                            "header": false
-                                                        }
+                                                "widgetID": "DateRangePicker"
+                                            },
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 24.714553309646,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Stats Chart",
+                                            "type": "component",
+                                            "component": "EIAnalyticsStatsChart",
+                                            "props": {
+                                                "id": "caa21446-1300-480b-af06-7eef4570414f",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber"
+                                                        ],
+                                                        "publishers": [
+                                                            "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
+                                                        ]
                                                     },
-                                                    "widgetID": "DateRangePicker"
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Request Count"
+                                                    }
                                                 },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 21.27257485911709,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Stats Chart",
-                                        "type": "component",
-                                        "component": "EIAnalyticsStatsChart",
-                                        "props": {
-                                            "id": "7ee63820-5894-4a62-bb95-350bd6b25182",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber"
-                                                    ],
-                                                    "publishers": [
-                                                        "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
-                                                        "ea185ba1-a50a-449e-a4f3-3200c78e391c"
-                                                    ],
-                                                    "widgetInputOutputMapping": [
+                                                "widgetID": "EIAnalyticsStatsChart"
+                                            },
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "row",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 20.22629716614896,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "height": 18.668444461415717,
+                                            "width": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "EI Analytics TPS",
+                                                    "type": "component",
+                                                    "component": "EIAnalyticsTPS",
+                                                    "props": {
+                                                        "id": "20ceb84d-a96d-402e-98d3-6845233b4e74",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "publishers": [
+                                                                    "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
 
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-                                                    "headerTitle": "Proxy Request Count"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "headerTitle": "Overall TPS"
+                                                            }
+                                                        },
+                                                        "widgetID": "EIAnalyticsTPS"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
                                                 }
-                                            },
-                                            "widgetID": "EIAnalyticsStatsChart"
+                                            ]
                                         },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "row",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 14.097111112513605,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "height": 11.887307405215838,
-                                        "width": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "[Proxy Message Count]",
-                                                "type": "component",
-                                                "component": "UniversalWidget",
-                                                "props": {
-                                                    "id": "e5b1ac69-0d99-4c32-a2b6-a64e0c7707ad",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "subscriberWidgetInputs": [
-                                                                "timeFrom",
-                                                                "timeTo",
-                                                                "timeUnit",
-                                                                "componentName"
-                                                            ],
-                                                            "publishers": [
-                                                                "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
-                                                                "ea185ba1-a50a-449e-a4f3-3200c78e391c"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-                                                                {
-                                                                    "subscriberWidgetInput": "timeFrom",
-                                                                    "publisherId": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
-                                                                    "publisherWidgetOutput": "from"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeTo",
-                                                                    "publisherId": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
-                                                                    "publisherWidgetOutput": "to"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeUnit",
-                                                                    "publisherId": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
-                                                                    "publisherWidgetOutput": "granularity"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "componentName",
-                                                                    "publisherId": "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
-                                                                    "publisherWidgetOutput": "selectedComponent"
-                                                                }
-                                                            ]
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "[Overall Message Count]",
+                                                    "type": "component",
+                                                    "component": "UniversalWidget",
+                                                    "props": {
+                                                        "id": "5df7940c-4cf7-4667-bcbd-8f96d0d904bd",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "subscriberWidgetInputs": [
+                                                                    "timeFrom",
+                                                                    "timeTo",
+                                                                    "timeUnit"
+                                                                ],
+                                                                "publishers": [
+                                                                    "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeFrom",
+                                                                        "publisherId": "aa53daba-1042-4a5b-9ebb-d74bf0770f3d",
+                                                                        "publisherWidgetOutput": "from"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeTo",
+                                                                        "publisherId": "aa53daba-1042-4a5b-9ebb-d74bf0770f3d",
+                                                                        "publisherWidgetOutput": "to"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeUnit",
+                                                                        "publisherId": "aa53daba-1042-4a5b-9ebb-d74bf0770f3d",
+                                                                        "publisherWidgetOutput": "granularity"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "isGenerated": true,
+                                                            "options": {
+                                                                "headerTitle": "Overall Message Count"
+                                                            }
                                                         },
-                                                        "isGenerated": true,
-                                                        "options": {
-                                                            "headerTitle": "Proxy Message Count"
-                                                        }
+                                                        "widgetID": "Overall-Message-Count"
                                                     },
-                                                    "widgetID": "Proxy-Message-Count"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "[Proxy Message Latency]",
-                                                "type": "component",
-                                                "component": "UniversalWidget",
-                                                "props": {
-                                                    "id": "14477e0c-d267-40af-a6be-cb210661479a",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "subscriberWidgetInputs": [
-                                                                "timeFrom",
-                                                                "timeTo",
-                                                                "timeUnit",
-                                                                "componentName"
-                                                            ],
-                                                            "publishers": [
-                                                                "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
-                                                                "ea185ba1-a50a-449e-a4f3-3200c78e391c"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-                                                                {
-                                                                    "subscriberWidgetInput": "timeFrom",
-                                                                    "publisherId": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
-                                                                    "publisherWidgetOutput": "from"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeTo",
-                                                                    "publisherId": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
-                                                                    "publisherWidgetOutput": "to"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeUnit",
-                                                                    "publisherId": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
-                                                                    "publisherWidgetOutput": "granularity"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "componentName",
-                                                                    "publisherId": "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
-                                                                    "publisherWidgetOutput": "selectedComponent"
-                                                                }
-                                                            ]
-                                                        },
-                                                        "isGenerated": true,
-                                                        "options": {
-                                                            "headerTitle": "Proxy Message Latency"
-                                                        }
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
                                                     },
-                                                    "widgetID": "Proxy-Message-Latency"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 21.90978006123472,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Message Table",
-                                        "type": "component",
-                                        "component": "EIAnalyticsMessageTable",
-                                        "props": {
-                                            "id": "607b714c-9c6b-4be7-a348-deb4fda96b84",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber"
-                                                    ],
-                                                    "publishers": [
-                                                        "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
-                                                        "ea185ba1-a50a-449e-a4f3-3200c78e391c"
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-                                                    "headerTitle": "Messages"
+                                                    "componentName": "lm-react-component"
                                                 }
-                                            },
-                                            "widgetID": "EIAnalyticsMessageTable"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 35.45131984714732,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Message Flow",
-                                        "type": "component",
-                                        "component": "EIAnalyticsMessageFlow",
-                                        "props": {
-                                            "id": "775a75c2-5e31-4dae-933f-932b32431b7f",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber",
-                                                        "publisher"
-                                                    ],
-                                                    "publishers": [
-                                                        "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
-                                                        "ea185ba1-a50a-449e-a4f3-3200c78e391c"
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-                                                  "headerTitle": "Message Flow"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "row",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 23.45429404540676,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "height": 25.0,
+                                            "width": 49.92917847025496,
+                                            "content": [
+                                                {
+                                                    "title": "EI Analytics Horizontal Bar Chart",
+                                                    "type": "component",
+                                                    "component": "EIAnalyticsHorizontalBarChart",
+                                                    "props": {
+                                                        "id": "1dba552a-d3a1-441f-b7b6-73b552182dda",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "publishers": [
+                                                                    "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "Component Type Selection": "proxy service",
+                                                                "headerTitle": "Top Proxy Services by Request Count"
+                                                            }
+                                                        },
+                                                        "widgetID": "EIAnalyticsHorizontalBarChart"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
                                                 }
-                                            },
-                                            "widgetID": "EIAnalyticsMessageFlow"
+                                            ]
                                         },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 50.07082152974505,
+                                            "content": [
+                                                {
+                                                    "title": "EI Analytics Horizontal Bar Chart",
+                                                    "type": "component",
+                                                    "component": "EIAnalyticsHorizontalBarChart",
+                                                    "props": {
+                                                        "id": "6b688b47-ef87-4114-90e6-3bd76766459c",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "publishers": [
+                                                                    "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "Component Type Selection": "api",
+                                                                "headerTitle": "Top APIs by Request Count"
+                                                            }
+                                                        },
+                                                        "widgetID": "EIAnalyticsHorizontalBarChart"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "row",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 22.226014307368,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "height": 100.0,
+                                            "width": 29.989094874591057,
+                                            "content": [
+                                                {
+                                                    "title": "EI Analytics Horizontal Bar Chart",
+                                                    "type": "component",
+                                                    "component": "EIAnalyticsHorizontalBarChart",
+                                                    "props": {
+                                                        "id": "f95513cb-2d88-4554-9982-8fe9d310c0ee",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "publishers": [
+                                                                    "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "Component Type Selection": "endpoint",
+                                                                "headerTitle": "Top Endpoints by Request Count"
+                                                            }
+                                                        },
+                                                        "widgetID": "EIAnalyticsHorizontalBarChart"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
                                         },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "height": 1994.0
-            },
-            {
-                "id": "api",
-                "name": "API",
-                "content": [
-                    {
-                        "type": "column",
-                        "isClosable": true,
-                        "title": "",
-                        "content": [
-                            {
-                                "type": "row",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 7.9261017428474645,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 33.165271669168355,
-                                        "height": 10.861092670659161,
-                                        "content": [
-                                            {
-                                                "title": "EI Analytics Search Box",
-                                                "type": "component",
-                                                "component": "EIAnalyticsSearchBox",
-                                                "props": {
-                                                    "id": "f4fea18c-d358-431e-81ad-49ae24bd7c90",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "publisher"
-                                                            ],
-                                                            "publisherWidgetOutputs": [
-                                                                "selectedComponent"
-                                                            ]
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 35.176781902660125,
+                                            "content": [
+                                                {
+                                                    "title": "EI Analytics Horizontal Bar Chart",
+                                                    "type": "component",
+                                                    "component": "EIAnalyticsHorizontalBarChart",
+                                                    "props": {
+                                                        "id": "af583379-fa88-412c-8f2f-9a91d11e8e1f",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "publishers": [
+                                                                    "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "Component Type Selection": "sequence",
+                                                                "headerTitle": "Top Sequences by Request Count"
+                                                            }
                                                         },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "header": false
-                                                        }
+                                                        "widgetID": "EIAnalyticsHorizontalBarChart"
                                                     },
-                                                    "widgetID": "EIAnalyticsSearchBox"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 66.83472833083164,
-                                        "content": [
-                                            {
-                                                "title": "Date Time Range",
-                                                "type": "component",
-                                                "component": "DateRangePicker",
-                                                "props": {
-                                                    "id": "cd941660-27d6-42eb-acbe-9e92de5fd144",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "publisher"
-                                                            ],
-                                                            "publisherWidgetOutputs": [
-                                                                "granularity",
-                                                                "from",
-                                                                "to"
-                                                            ]
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 34.834123222748815,
+                                            "content": [
+                                                {
+                                                    "title": "EI Analytics Horizontal Bar Chart",
+                                                    "type": "component",
+                                                    "component": "EIAnalyticsHorizontalBarChart",
+                                                    "props": {
+                                                        "id": "31a90bea-f5b3-4bcc-bf5c-1b7645066233",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "publishers": [
+                                                                    "aa53daba-1042-4a5b-9ebb-d74bf0770f3d"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "Component Type Selection": "inbound endpoint",
+                                                                "headerTitle": "Top Inbound Endpoints by Request Count"
+                                                            }
                                                         },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "defaultValue": "3 Months",
-                                                            "availableGranularities": "From Second",
-                                                            "autoSyncInterval": "10",
-                                                            "header": false
-                                                        }
+                                                        "widgetID": "EIAnalyticsHorizontalBarChart"
                                                     },
-                                                    "widgetID": "DateRangePicker"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 19.59690997749551,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Stats Chart",
-                                        "type": "component",
-                                        "component": "EIAnalyticsStatsChart",
-                                        "props": {
-                                            "id": "bd3a4e62-60f5-4ff2-ac2b-14541dcc39f7",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber"
-                                                    ],
-                                                    "publishers": [
-                                                        "f4fea18c-d358-431e-81ad-49ae24bd7c90",
-                                                        "cd941660-27d6-42eb-acbe-9e92de5fd144"
-                                                    ],
-                                                    "widgetInputOutputMapping": [
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "height": 1714.0
+                },
+                {
+                    "id": "proxy",
+                    "name": "Proxy Services",
+                    "content": [
+                        {
+                            "type": "column",
+                            "isClosable": true,
+                            "title": "",
+                            "content": [
+                                {
+                                    "type": "row",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 9.906580958757585,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 33.56871758426203,
+                                            "height": 7.849504987941964,
+                                            "content": [
+                                                {
+                                                    "title": "EI Analytics Search Box",
+                                                    "type": "component",
+                                                    "component": "EIAnalyticsSearchBox",
+                                                    "props": {
+                                                        "id": "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "publisher"
+                                                                ],
+                                                                "publisherWidgetOutputs": [
+                                                                    "selectedComponent"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "header": false
+                                                            }
+                                                        },
+                                                        "widgetID": "EIAnalyticsSearchBox"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 66.431282415738,
+                                            "content": [
+                                                {
+                                                    "title": "Date Time Range",
+                                                    "type": "component",
+                                                    "component": "DateRangePicker",
+                                                    "props": {
+                                                        "id": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "publisher"
+                                                                ],
+                                                                "publisherWidgetOutputs": [
+                                                                    "granularity",
+                                                                    "from",
+                                                                    "to"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "defaultValue": "3 Months",
+                                                                "availableGranularities": "From Second",
+                                                                "autoSyncInterval": "10",
+                                                                "header": false
+                                                            }
+                                                        },
+                                                        "widgetID": "DateRangePicker"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 21.27257485911709,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Stats Chart",
+                                            "type": "component",
+                                            "component": "EIAnalyticsStatsChart",
+                                            "props": {
+                                                "id": "7ee63820-5894-4a62-bb95-350bd6b25182",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber"
+                                                        ],
+                                                        "publishers": [
+                                                            "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
+                                                            "ea185ba1-a50a-449e-a4f3-3200c78e391c"
+                                                        ],
+                                                        "widgetInputOutputMapping": [
 
-                                                    ]
+                                                        ]
+                                                    },
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Proxy Request Count"
+                                                    }
                                                 },
-                                                "isGenerated": false,
-                                                "options": {
-                                                    "headerTitle": "API Request Count"
-                                                }
+                                                "widgetID": "EIAnalyticsStatsChart"
                                             },
-                                            "widgetID": "EIAnalyticsStatsChart"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "row",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 16.44583701792902,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "height": 13.083318811051978,
-                                        "width": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "[API Message Count]",
-                                                "type": "component",
-                                                "component": "UniversalWidget",
-                                                "props": {
-                                                    "id": "aef05649-9c70-435f-9fdd-16552333819e",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "subscriberWidgetInputs": [
-                                                                "timeFrom",
-                                                                "timeTo",
-                                                                "timeUnit",
-                                                                "componentName"
-                                                            ],
-                                                            "publishers": [
-                                                                "f4fea18c-d358-431e-81ad-49ae24bd7c90",
-                                                                "cd941660-27d6-42eb-acbe-9e92de5fd144"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-                                                                {
-                                                                    "subscriberWidgetInput": "timeFrom",
-                                                                    "publisherId": "cd941660-27d6-42eb-acbe-9e92de5fd144",
-                                                                    "publisherWidgetOutput": "from"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeTo",
-                                                                    "publisherId": "cd941660-27d6-42eb-acbe-9e92de5fd144",
-                                                                    "publisherWidgetOutput": "to"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeUnit",
-                                                                    "publisherId": "cd941660-27d6-42eb-acbe-9e92de5fd144",
-                                                                    "publisherWidgetOutput": "granularity"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "componentName",
-                                                                    "publisherId": "f4fea18c-d358-431e-81ad-49ae24bd7c90",
-                                                                    "publisherWidgetOutput": "selectedComponent"
-                                                                }
-                                                            ]
-                                                        },
-                                                        "isGenerated": true,
-                                                        "options": {
-                                                            "headerTitle": "API Message Count"
-                                                        }
-                                                    },
-                                                    "widgetID": "API-Message-Count"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "[API Message Latency]",
-                                                "type": "component",
-                                                "component": "UniversalWidget",
-                                                "props": {
-                                                    "id": "278f74a7-dc20-419a-805b-10fe0edf1620",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "subscriberWidgetInputs": [
-                                                                "timeFrom",
-                                                                "timeTo",
-                                                                "timeUnit",
-                                                                "componentName"
-                                                            ],
-                                                            "publishers": [
-                                                                "f4fea18c-d358-431e-81ad-49ae24bd7c90",
-                                                                "cd941660-27d6-42eb-acbe-9e92de5fd144"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-                                                                {
-                                                                    "subscriberWidgetInput": "timeFrom",
-                                                                    "publisherId": "cd941660-27d6-42eb-acbe-9e92de5fd144",
-                                                                    "publisherWidgetOutput": "from"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeTo",
-                                                                    "publisherId": "cd941660-27d6-42eb-acbe-9e92de5fd144",
-                                                                    "publisherWidgetOutput": "to"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeUnit",
-                                                                    "publisherId": "cd941660-27d6-42eb-acbe-9e92de5fd144",
-                                                                    "publisherWidgetOutput": "granularity"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "componentName",
-                                                                    "publisherId": "f4fea18c-d358-431e-81ad-49ae24bd7c90",
-                                                                    "publisherWidgetOutput": "selectedComponent"
-                                                                }
-                                                            ]
-                                                        },
-                                                        "isGenerated": true,
-                                                        "options": {
-                                                            "headerTitle": "API Message Latency"
-                                                        }
-                                                    },
-                                                    "widgetID": "API-Message-Latency"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 21.575753715715734,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Message Table",
-                                        "type": "component",
-                                        "component": "EIAnalyticsMessageTable",
-                                        "props": {
-                                            "id": "af4587aa-8113-40d0-9cec-0df46f53c9cc",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber"
-                                                    ],
-                                                    "publishers": [
-                                                        "f4fea18c-d358-431e-81ad-49ae24bd7c90",
-                                                        "cd941660-27d6-42eb-acbe-9e92de5fd144"
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-                                                    "headerTitle": "Messages"
-                                                }
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
                                             },
-                                            "widgetID": "EIAnalyticsMessageTable"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 34.45539754601228,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Message Flow",
-                                        "type": "component",
-                                        "component": "EIAnalyticsMessageFlow",
-                                        "props": {
-                                            "id": "2dd53247-e403-41c4-9d03-ee0c95166f1f",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber",
-                                                        "publisher"
-                                                    ],
-                                                    "publishers": [
-                                                        "f4fea18c-d358-431e-81ad-49ae24bd7c90",
-                                                        "cd941660-27d6-42eb-acbe-9e92de5fd144"
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-                                                  "headerTitle": "Message Flow"
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "row",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 14.097111112513605,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "height": 11.887307405215838,
+                                            "width": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "[Proxy Message Count]",
+                                                    "type": "component",
+                                                    "component": "UniversalWidget",
+                                                    "props": {
+                                                        "id": "e5b1ac69-0d99-4c32-a2b6-a64e0c7707ad",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "subscriberWidgetInputs": [
+                                                                    "timeFrom",
+                                                                    "timeTo",
+                                                                    "timeUnit",
+                                                                    "componentName"
+                                                                ],
+                                                                "publishers": [
+                                                                    "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
+                                                                    "ea185ba1-a50a-449e-a4f3-3200c78e391c"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeFrom",
+                                                                        "publisherId": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
+                                                                        "publisherWidgetOutput": "from"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeTo",
+                                                                        "publisherId": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
+                                                                        "publisherWidgetOutput": "to"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeUnit",
+                                                                        "publisherId": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
+                                                                        "publisherWidgetOutput": "granularity"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "componentName",
+                                                                        "publisherId": "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
+                                                                        "publisherWidgetOutput": "selectedComponent"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "isGenerated": true,
+                                                            "options": {
+                                                                "headerTitle": "Proxy Message Count"
+                                                            }
+                                                        },
+                                                        "widgetID": "Proxy-Message-Count"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
                                                 }
+                                            ]
+                                        },
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "[Proxy Message Latency]",
+                                                    "type": "component",
+                                                    "component": "UniversalWidget",
+                                                    "props": {
+                                                        "id": "14477e0c-d267-40af-a6be-cb210661479a",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "subscriberWidgetInputs": [
+                                                                    "timeFrom",
+                                                                    "timeTo",
+                                                                    "timeUnit",
+                                                                    "componentName"
+                                                                ],
+                                                                "publishers": [
+                                                                    "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
+                                                                    "ea185ba1-a50a-449e-a4f3-3200c78e391c"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeFrom",
+                                                                        "publisherId": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
+                                                                        "publisherWidgetOutput": "from"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeTo",
+                                                                        "publisherId": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
+                                                                        "publisherWidgetOutput": "to"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeUnit",
+                                                                        "publisherId": "ea185ba1-a50a-449e-a4f3-3200c78e391c",
+                                                                        "publisherWidgetOutput": "granularity"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "componentName",
+                                                                        "publisherId": "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
+                                                                        "publisherWidgetOutput": "selectedComponent"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "isGenerated": true,
+                                                            "options": {
+                                                                "headerTitle": "Proxy Message Latency"
+                                                            }
+                                                        },
+                                                        "widgetID": "Proxy-Message-Latency"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 21.90978006123472,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Message Table",
+                                            "type": "component",
+                                            "component": "EIAnalyticsMessageTable",
+                                            "props": {
+                                                "id": "607b714c-9c6b-4be7-a348-deb4fda96b84",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber"
+                                                        ],
+                                                        "publishers": [
+                                                            "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
+                                                            "ea185ba1-a50a-449e-a4f3-3200c78e391c"
+                                                        ]
+                                                    },
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Messages"
+                                                    }
+                                                },
+                                                "widgetID": "EIAnalyticsMessageTable"
                                             },
-                                            "widgetID": "EIAnalyticsMessageFlow"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "height": 2121.0
-            },
-            {
-                "id": "sequence",
-                "name": "Sequence",
-                "content": [
-                    {
-                        "type": "column",
-                        "isClosable": true,
-                        "title": "",
-                        "content": [
-                            {
-                                "type": "row",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 9.139958413380972,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "height": 9.086458721969501,
-                                        "width": 33.165271669168355,
-                                        "content": [
-                                            {
-                                                "title": "EI Analytics Search Box",
-                                                "type": "component",
-                                                "component": "EIAnalyticsSearchBox",
-                                                "props": {
-                                                    "id": "a93d734b-c943-4460-ba0b-b7a894433ffa",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "publisher"
-                                                            ],
-                                                            "publisherWidgetOutputs": [
-                                                                "selectedComponent"
-                                                            ]
-                                                        },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "header": false
-                                                        }
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 35.45131984714732,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Message Flow",
+                                            "type": "component",
+                                            "component": "EIAnalyticsMessageFlow",
+                                            "props": {
+                                                "id": "775a75c2-5e31-4dae-933f-932b32431b7f",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber",
+                                                            "publisher"
+                                                        ],
+                                                        "publishers": [
+                                                            "e5cf3e3f-3662-4c89-905e-9fa8f0358091",
+                                                            "ea185ba1-a50a-449e-a4f3-3200c78e391c"
+                                                        ]
                                                     },
-                                                    "widgetID": "EIAnalyticsSearchBox"
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Message Flow"
+                                                    }
                                                 },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 66.83472833083164,
-                                        "content": [
-                                            {
-                                                "title": "Date Time Range",
-                                                "type": "component",
-                                                "component": "DateRangePicker",
-                                                "props": {
-                                                    "id": "00674be1-08d6-4446-a4c9-06d062376a28",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "publisher"
-                                                            ],
-                                                            "publisherWidgetOutputs": [
-                                                                "granularity",
-                                                                "from",
-                                                                "to"
-                                                            ]
+                                                "widgetID": "EIAnalyticsMessageFlow"
+                                            },
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "height": 1994.0
+                },
+                {
+                    "id": "api",
+                    "name": "API",
+                    "content": [
+                        {
+                            "type": "column",
+                            "isClosable": true,
+                            "title": "",
+                            "content": [
+                                {
+                                    "type": "row",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 7.9261017428474645,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 33.165271669168355,
+                                            "height": 10.861092670659161,
+                                            "content": [
+                                                {
+                                                    "title": "EI Analytics Search Box",
+                                                    "type": "component",
+                                                    "component": "EIAnalyticsSearchBox",
+                                                    "props": {
+                                                        "id": "f4fea18c-d358-431e-81ad-49ae24bd7c90",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "publisher"
+                                                                ],
+                                                                "publisherWidgetOutputs": [
+                                                                    "selectedComponent"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "header": false
+                                                            }
                                                         },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "defaultValue": "3 Months",
-                                                            "availableGranularities": "From Second",
-                                                            "autoSyncInterval": "10",
-                                                            "header": false
-                                                        }
+                                                        "widgetID": "EIAnalyticsSearchBox"
                                                     },
-                                                    "widgetID": "DateRangePicker"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 21.155409361308767,
-                                "width": 100.0,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Stats Chart",
-                                        "type": "component",
-                                        "component": "EIAnalyticsStatsChart",
-                                        "props": {
-                                            "id": "b689147a-11d1-4f02-902e-b3e40f7a7cb6",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber"
-                                                    ],
-                                                    "publishers": [
-                                                        "a93d734b-c943-4460-ba0b-b7a894433ffa",
-                                                        "00674be1-08d6-4446-a4c9-06d062376a28"
-                                                    ],
-                                                    "widgetInputOutputMapping": [
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 66.83472833083164,
+                                            "content": [
+                                                {
+                                                    "title": "Date Time Range",
+                                                    "type": "component",
+                                                    "component": "DateRangePicker",
+                                                    "props": {
+                                                        "id": "cd941660-27d6-42eb-acbe-9e92de5fd144",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "publisher"
+                                                                ],
+                                                                "publisherWidgetOutputs": [
+                                                                    "granularity",
+                                                                    "from",
+                                                                    "to"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "defaultValue": "3 Months",
+                                                                "availableGranularities": "From Second",
+                                                                "autoSyncInterval": "10",
+                                                                "header": false
+                                                            }
+                                                        },
+                                                        "widgetID": "DateRangePicker"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 19.59690997749551,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Stats Chart",
+                                            "type": "component",
+                                            "component": "EIAnalyticsStatsChart",
+                                            "props": {
+                                                "id": "bd3a4e62-60f5-4ff2-ac2b-14541dcc39f7",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber"
+                                                        ],
+                                                        "publishers": [
+                                                            "f4fea18c-d358-431e-81ad-49ae24bd7c90",
+                                                            "cd941660-27d6-42eb-acbe-9e92de5fd144"
+                                                        ],
+                                                        "widgetInputOutputMapping": [
 
-                                                    ]
+                                                        ]
+                                                    },
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "API Request Count"
+                                                    }
                                                 },
-                                                "isGenerated": false,
-                                                "options": {
-                                                    "headerTitle": "Sequence Request Count"
-                                                }
+                                                "widgetID": "EIAnalyticsStatsChart"
                                             },
-                                            "widgetID": "EIAnalyticsStatsChart"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "row",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 15.70434884332247,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "height": 11.53980105855789,
-                                        "width": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "[Sequence Message Count]",
-                                                "type": "component",
-                                                "component": "UniversalWidget",
-                                                "props": {
-                                                    "id": "9131c3bb-a8d8-4b9a-a5cf-406044cb32f7",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "subscriberWidgetInputs": [
-                                                                "timeFrom",
-                                                                "timeTo",
-                                                                "timeUnit",
-                                                                "componentName"
-                                                            ],
-                                                            "publishers": [
-                                                                "a93d734b-c943-4460-ba0b-b7a894433ffa",
-                                                                "00674be1-08d6-4446-a4c9-06d062376a28"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-                                                                {
-                                                                    "subscriberWidgetInput": "timeFrom",
-                                                                    "publisherId": "00674be1-08d6-4446-a4c9-06d062376a28",
-                                                                    "publisherWidgetOutput": "from"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeTo",
-                                                                    "publisherId": "00674be1-08d6-4446-a4c9-06d062376a28",
-                                                                    "publisherWidgetOutput": "to"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeUnit",
-                                                                    "publisherId": "00674be1-08d6-4446-a4c9-06d062376a28",
-                                                                    "publisherWidgetOutput": "granularity"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "componentName",
-                                                                    "publisherId": "a93d734b-c943-4460-ba0b-b7a894433ffa",
-                                                                    "publisherWidgetOutput": "selectedComponent"
-                                                                }
-                                                            ]
-                                                        },
-                                                        "isGenerated": true,
-                                                        "options": {
-                                                            "headerTitle": "Sequence Message Count"
-                                                        }
-                                                    },
-                                                    "widgetID": "Sequence-Message-Count"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "[Sequence Message Latency]",
-                                                "type": "component",
-                                                "component": "UniversalWidget",
-                                                "props": {
-                                                    "id": "52af2fb2-06c5-431b-928a-2663bf70097c",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "subscriberWidgetInputs": [
-                                                                "timeFrom",
-                                                                "timeTo",
-                                                                "timeUnit",
-                                                                "componentName"
-                                                            ],
-                                                            "publishers": [
-                                                                "a93d734b-c943-4460-ba0b-b7a894433ffa",
-                                                                "00674be1-08d6-4446-a4c9-06d062376a28"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-                                                                {
-                                                                    "subscriberWidgetInput": "timeFrom",
-                                                                    "publisherId": "00674be1-08d6-4446-a4c9-06d062376a28",
-                                                                    "publisherWidgetOutput": "from"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeTo",
-                                                                    "publisherId": "00674be1-08d6-4446-a4c9-06d062376a28",
-                                                                    "publisherWidgetOutput": "to"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeUnit",
-                                                                    "publisherId": "00674be1-08d6-4446-a4c9-06d062376a28",
-                                                                    "publisherWidgetOutput": "granularity"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "componentName",
-                                                                    "publisherId": "a93d734b-c943-4460-ba0b-b7a894433ffa",
-                                                                    "publisherWidgetOutput": "selectedComponent"
-                                                                }
-                                                            ]
-                                                        },
-                                                        "isGenerated": true,
-                                                        "options": {
-                                                            "headerTitle": "Sequence Message Latency"
-                                                        }
-                                                    },
-                                                    "widgetID": "Sequence-Message-Latency"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 20.95489997842279,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Message Table",
-                                        "type": "component",
-                                        "component": "EIAnalyticsMessageTable",
-                                        "props": {
-                                            "id": "a3506d95-fc60-4b4c-ac1f-460537160bda",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber"
-                                                    ],
-                                                    "publishers": [
-                                                        "a93d734b-c943-4460-ba0b-b7a894433ffa",
-                                                        "00674be1-08d6-4446-a4c9-06d062376a28"
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-                                                    "headerTitle": "Messages"
-                                                }
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
                                             },
-                                            "widgetID": "EIAnalyticsMessageTable"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 33.045383403565005,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Message Flow",
-                                        "type": "component",
-                                        "component": "EIAnalyticsMessageFlow",
-                                        "props": {
-                                            "id": "3b9157a9-dabc-4af7-9a28-e132e457ef45",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber",
-                                                        "publisher"
-                                                    ],
-                                                    "publishers": [
-                                                        "a93d734b-c943-4460-ba0b-b7a894433ffa",
-                                                        "00674be1-08d6-4446-a4c9-06d062376a28"
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-                                                  "headerTitle": "Message Flow"
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "row",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 16.44583701792902,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "height": 13.083318811051978,
+                                            "width": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "[API Message Count]",
+                                                    "type": "component",
+                                                    "component": "UniversalWidget",
+                                                    "props": {
+                                                        "id": "aef05649-9c70-435f-9fdd-16552333819e",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "subscriberWidgetInputs": [
+                                                                    "timeFrom",
+                                                                    "timeTo",
+                                                                    "timeUnit",
+                                                                    "componentName"
+                                                                ],
+                                                                "publishers": [
+                                                                    "f4fea18c-d358-431e-81ad-49ae24bd7c90",
+                                                                    "cd941660-27d6-42eb-acbe-9e92de5fd144"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeFrom",
+                                                                        "publisherId": "cd941660-27d6-42eb-acbe-9e92de5fd144",
+                                                                        "publisherWidgetOutput": "from"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeTo",
+                                                                        "publisherId": "cd941660-27d6-42eb-acbe-9e92de5fd144",
+                                                                        "publisherWidgetOutput": "to"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeUnit",
+                                                                        "publisherId": "cd941660-27d6-42eb-acbe-9e92de5fd144",
+                                                                        "publisherWidgetOutput": "granularity"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "componentName",
+                                                                        "publisherId": "f4fea18c-d358-431e-81ad-49ae24bd7c90",
+                                                                        "publisherWidgetOutput": "selectedComponent"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "isGenerated": true,
+                                                            "options": {
+                                                                "headerTitle": "API Message Count"
+                                                            }
+                                                        },
+                                                        "widgetID": "API-Message-Count"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
                                                 }
+                                            ]
+                                        },
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "[API Message Latency]",
+                                                    "type": "component",
+                                                    "component": "UniversalWidget",
+                                                    "props": {
+                                                        "id": "278f74a7-dc20-419a-805b-10fe0edf1620",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "subscriberWidgetInputs": [
+                                                                    "timeFrom",
+                                                                    "timeTo",
+                                                                    "timeUnit",
+                                                                    "componentName"
+                                                                ],
+                                                                "publishers": [
+                                                                    "f4fea18c-d358-431e-81ad-49ae24bd7c90",
+                                                                    "cd941660-27d6-42eb-acbe-9e92de5fd144"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeFrom",
+                                                                        "publisherId": "cd941660-27d6-42eb-acbe-9e92de5fd144",
+                                                                        "publisherWidgetOutput": "from"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeTo",
+                                                                        "publisherId": "cd941660-27d6-42eb-acbe-9e92de5fd144",
+                                                                        "publisherWidgetOutput": "to"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeUnit",
+                                                                        "publisherId": "cd941660-27d6-42eb-acbe-9e92de5fd144",
+                                                                        "publisherWidgetOutput": "granularity"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "componentName",
+                                                                        "publisherId": "f4fea18c-d358-431e-81ad-49ae24bd7c90",
+                                                                        "publisherWidgetOutput": "selectedComponent"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "isGenerated": true,
+                                                            "options": {
+                                                                "headerTitle": "API Message Latency"
+                                                            }
+                                                        },
+                                                        "widgetID": "API-Message-Latency"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 21.575753715715734,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Message Table",
+                                            "type": "component",
+                                            "component": "EIAnalyticsMessageTable",
+                                            "props": {
+                                                "id": "af4587aa-8113-40d0-9cec-0df46f53c9cc",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber"
+                                                        ],
+                                                        "publishers": [
+                                                            "f4fea18c-d358-431e-81ad-49ae24bd7c90",
+                                                            "cd941660-27d6-42eb-acbe-9e92de5fd144"
+                                                        ]
+                                                    },
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Messages"
+                                                    }
+                                                },
+                                                "widgetID": "EIAnalyticsMessageTable"
                                             },
-                                            "widgetID": "EIAnalyticsMessageFlow"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "height": 1964.0
-            },
-            {
-                "id": "endpoint",
-                "name": "Endpoint",
-                "content": [
-                    {
-                        "type": "column",
-                        "isClosable": true,
-                        "title": "",
-                        "content": [
-                            {
-                                "type": "row",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 14.214308430294809,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 33.11486829093233,
-                                        "height": 15.971962755248521,
-                                        "content": [
-                                            {
-                                                "title": "EI Analytics Search Box",
-                                                "type": "component",
-                                                "component": "EIAnalyticsSearchBox",
-                                                "props": {
-                                                    "id": "3865a05b-8f2e-40b3-a9a0-babbff15b622",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "publisher"
-                                                            ],
-                                                            "publisherWidgetOutputs": [
-                                                                "selectedComponent"
-                                                            ]
-                                                        },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "header": false
-                                                        }
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 34.45539754601228,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Message Flow",
+                                            "type": "component",
+                                            "component": "EIAnalyticsMessageFlow",
+                                            "props": {
+                                                "id": "2dd53247-e403-41c4-9d03-ee0c95166f1f",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber",
+                                                            "publisher"
+                                                        ],
+                                                        "publishers": [
+                                                            "f4fea18c-d358-431e-81ad-49ae24bd7c90",
+                                                            "cd941660-27d6-42eb-acbe-9e92de5fd144"
+                                                        ]
                                                     },
-                                                    "widgetID": "EIAnalyticsSearchBox"
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Message Flow"
+                                                    }
                                                 },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 66.88513170906766,
-                                        "content": [
-                                            {
-                                                "title": "Date Time Range",
-                                                "type": "component",
-                                                "component": "DateRangePicker",
-                                                "props": {
-                                                    "id": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "publisher"
-                                                            ],
-                                                            "publisherWidgetOutputs": [
-                                                                "granularity",
-                                                                "from",
-                                                                "to"
-                                                            ]
+                                                "widgetID": "EIAnalyticsMessageFlow"
+                                            },
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "height": 2121.0
+                },
+                {
+                    "id": "sequence",
+                    "name": "Sequence",
+                    "content": [
+                        {
+                            "type": "column",
+                            "isClosable": true,
+                            "title": "",
+                            "content": [
+                                {
+                                    "type": "row",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 9.139958413380972,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "height": 9.086458721969501,
+                                            "width": 33.165271669168355,
+                                            "content": [
+                                                {
+                                                    "title": "EI Analytics Search Box",
+                                                    "type": "component",
+                                                    "component": "EIAnalyticsSearchBox",
+                                                    "props": {
+                                                        "id": "a93d734b-c943-4460-ba0b-b7a894433ffa",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "publisher"
+                                                                ],
+                                                                "publisherWidgetOutputs": [
+                                                                    "selectedComponent"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "header": false
+                                                            }
                                                         },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "defaultValue": "3 Months",
-                                                            "availableGranularities": "From Second",
-                                                            "autoSyncInterval": "10",
-                                                            "header": false
-                                                        }
+                                                        "widgetID": "EIAnalyticsSearchBox"
                                                     },
-                                                    "widgetID": "DateRangePicker"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 34.69254938919411,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Stats Chart",
-                                        "type": "component",
-                                        "component": "EIAnalyticsStatsChart",
-                                        "props": {
-                                            "id": "9c7f2585-8a45-46bc-9228-083354f72c46",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber"
-                                                    ],
-                                                    "publishers": [
-                                                        "3865a05b-8f2e-40b3-a9a0-babbff15b622",
-                                                        "84e1a9ea-64c0-412a-a99e-1ffb88502778"
-                                                    ],
-                                                    "widgetInputOutputMapping": [
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 66.83472833083164,
+                                            "content": [
+                                                {
+                                                    "title": "Date Time Range",
+                                                    "type": "component",
+                                                    "component": "DateRangePicker",
+                                                    "props": {
+                                                        "id": "00674be1-08d6-4446-a4c9-06d062376a28",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "publisher"
+                                                                ],
+                                                                "publisherWidgetOutputs": [
+                                                                    "granularity",
+                                                                    "from",
+                                                                    "to"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "defaultValue": "3 Months",
+                                                                "availableGranularities": "From Second",
+                                                                "autoSyncInterval": "10",
+                                                                "header": false
+                                                            }
+                                                        },
+                                                        "widgetID": "DateRangePicker"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 21.155409361308767,
+                                    "width": 100.0,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Stats Chart",
+                                            "type": "component",
+                                            "component": "EIAnalyticsStatsChart",
+                                            "props": {
+                                                "id": "b689147a-11d1-4f02-902e-b3e40f7a7cb6",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber"
+                                                        ],
+                                                        "publishers": [
+                                                            "a93d734b-c943-4460-ba0b-b7a894433ffa",
+                                                            "00674be1-08d6-4446-a4c9-06d062376a28"
+                                                        ],
+                                                        "widgetInputOutputMapping": [
 
-                                                    ]
+                                                        ]
+                                                    },
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Sequence Request Count"
+                                                    }
                                                 },
-                                                "isGenerated": false,
-                                                "options": {
-                                                    "headerTitle": "Endpoint Request Count"
-                                                }
+                                                "widgetID": "EIAnalyticsStatsChart"
                                             },
-                                            "widgetID": "EIAnalyticsStatsChart"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "row",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 22.734395675502505,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "height": 17.71053121060733,
-                                        "width": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "[Endpoint Message Count]",
-                                                "type": "component",
-                                                "component": "UniversalWidget",
-                                                "props": {
-                                                    "id": "27520bf9-5470-47c5-b96c-f52244f11fc8",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "subscriberWidgetInputs": [
-                                                                "timeFrom",
-                                                                "timeTo",
-                                                                "timeUnit",
-                                                                "componentName"
-                                                            ],
-                                                            "publishers": [
-                                                                "3865a05b-8f2e-40b3-a9a0-babbff15b622",
-                                                                "84e1a9ea-64c0-412a-a99e-1ffb88502778"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-                                                                {
-                                                                    "subscriberWidgetInput": "timeFrom",
-                                                                    "publisherId": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
-                                                                    "publisherWidgetOutput": "from"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeTo",
-                                                                    "publisherId": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
-                                                                    "publisherWidgetOutput": "to"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeUnit",
-                                                                    "publisherId": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
-                                                                    "publisherWidgetOutput": "granularity"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "componentName",
-                                                                    "publisherId": "3865a05b-8f2e-40b3-a9a0-babbff15b622",
-                                                                    "publisherWidgetOutput": "selectedComponent"
-                                                                }
-                                                            ]
-                                                        },
-                                                        "isGenerated": true,
-                                                        "options": {
-                                                            "headerTitle": "Endpoint Message Count"
-                                                        }
-                                                    },
-                                                    "widgetID": "Endpoint-Message-Count"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "[Endpoint Message Latency]",
-                                                "type": "component",
-                                                "component": "UniversalWidget",
-                                                "props": {
-                                                    "id": "e653dbfa-1f32-425e-99de-0c258d366dd9",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "subscriberWidgetInputs": [
-                                                                "timeFrom",
-                                                                "timeTo",
-                                                                "timeUnit",
-                                                                "componentName"
-                                                            ],
-                                                            "publishers": [
-                                                                "3865a05b-8f2e-40b3-a9a0-babbff15b622",
-                                                                "84e1a9ea-64c0-412a-a99e-1ffb88502778"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-                                                                {
-                                                                    "subscriberWidgetInput": "timeFrom",
-                                                                    "publisherId": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
-                                                                    "publisherWidgetOutput": "from"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeTo",
-                                                                    "publisherId": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
-                                                                    "publisherWidgetOutput": "to"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeUnit",
-                                                                    "publisherId": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
-                                                                    "publisherWidgetOutput": "granularity"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "componentName",
-                                                                    "publisherId": "3865a05b-8f2e-40b3-a9a0-babbff15b622",
-                                                                    "publisherWidgetOutput": "selectedComponent"
-                                                                }
-                                                            ]
-                                                        },
-                                                        "isGenerated": true,
-                                                        "options": {
-                                                            "headerTitle": "Endpoint Message Latency"
-                                                        }
-                                                    },
-                                                    "widgetID": "Endpoint-Message-Latency"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 28.358746505008604,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Message Table",
-                                        "type": "component",
-                                        "component": "EIAnalyticsMessageTable",
-                                        "props": {
-                                            "id": "40de7705-a760-4e1d-8554-25a04ed7dd1f",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber"
-                                                    ],
-                                                    "publishers": [
-                                                        "3865a05b-8f2e-40b3-a9a0-babbff15b622",
-                                                        "84e1a9ea-64c0-412a-a99e-1ffb88502778"
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-                                                    "headerTitle": "Messages"
-                                                }
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
                                             },
-                                            "widgetID": "EIAnalyticsMessageTable"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "height": 1260.7999877929688
-            },
-            {
-                "id": "inbound",
-                "name": "Inbound Endpoint",
-                "content": [
-                    {
-                        "type": "column",
-                        "isClosable": true,
-                        "title": "",
-                        "content": [
-                            {
-                                "type": "row",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 7.727225497543937,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 33.06446491269631,
-                                        "content": [
-                                            {
-                                                "title": "EI Analytics Search Box",
-                                                "type": "component",
-                                                "component": "EIAnalyticsSearchBox",
-                                                "props": {
-                                                    "id": "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "publisher"
-                                                            ],
-                                                            "publisherWidgetOutputs": [
-                                                                "selectedComponent"
-                                                            ]
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "row",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 15.70434884332247,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "height": 11.53980105855789,
+                                            "width": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "[Sequence Message Count]",
+                                                    "type": "component",
+                                                    "component": "UniversalWidget",
+                                                    "props": {
+                                                        "id": "9131c3bb-a8d8-4b9a-a5cf-406044cb32f7",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "subscriberWidgetInputs": [
+                                                                    "timeFrom",
+                                                                    "timeTo",
+                                                                    "timeUnit",
+                                                                    "componentName"
+                                                                ],
+                                                                "publishers": [
+                                                                    "a93d734b-c943-4460-ba0b-b7a894433ffa",
+                                                                    "00674be1-08d6-4446-a4c9-06d062376a28"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeFrom",
+                                                                        "publisherId": "00674be1-08d6-4446-a4c9-06d062376a28",
+                                                                        "publisherWidgetOutput": "from"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeTo",
+                                                                        "publisherId": "00674be1-08d6-4446-a4c9-06d062376a28",
+                                                                        "publisherWidgetOutput": "to"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeUnit",
+                                                                        "publisherId": "00674be1-08d6-4446-a4c9-06d062376a28",
+                                                                        "publisherWidgetOutput": "granularity"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "componentName",
+                                                                        "publisherId": "a93d734b-c943-4460-ba0b-b7a894433ffa",
+                                                                        "publisherWidgetOutput": "selectedComponent"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "isGenerated": true,
+                                                            "options": {
+                                                                "headerTitle": "Sequence Message Count"
+                                                            }
                                                         },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "header": false
-                                                        }
+                                                        "widgetID": "Sequence-Message-Count"
                                                     },
-                                                    "widgetID": "EIAnalyticsSearchBox"
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "[Sequence Message Latency]",
+                                                    "type": "component",
+                                                    "component": "UniversalWidget",
+                                                    "props": {
+                                                        "id": "52af2fb2-06c5-431b-928a-2663bf70097c",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "subscriberWidgetInputs": [
+                                                                    "timeFrom",
+                                                                    "timeTo",
+                                                                    "timeUnit",
+                                                                    "componentName"
+                                                                ],
+                                                                "publishers": [
+                                                                    "a93d734b-c943-4460-ba0b-b7a894433ffa",
+                                                                    "00674be1-08d6-4446-a4c9-06d062376a28"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeFrom",
+                                                                        "publisherId": "00674be1-08d6-4446-a4c9-06d062376a28",
+                                                                        "publisherWidgetOutput": "from"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeTo",
+                                                                        "publisherId": "00674be1-08d6-4446-a4c9-06d062376a28",
+                                                                        "publisherWidgetOutput": "to"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeUnit",
+                                                                        "publisherId": "00674be1-08d6-4446-a4c9-06d062376a28",
+                                                                        "publisherWidgetOutput": "granularity"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "componentName",
+                                                                        "publisherId": "a93d734b-c943-4460-ba0b-b7a894433ffa",
+                                                                        "publisherWidgetOutput": "selectedComponent"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "isGenerated": true,
+                                                            "options": {
+                                                                "headerTitle": "Sequence Message Latency"
+                                                            }
+                                                        },
+                                                        "widgetID": "Sequence-Message-Latency"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 20.95489997842279,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Message Table",
+                                            "type": "component",
+                                            "component": "EIAnalyticsMessageTable",
+                                            "props": {
+                                                "id": "a3506d95-fc60-4b4c-ac1f-460537160bda",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber"
+                                                        ],
+                                                        "publishers": [
+                                                            "a93d734b-c943-4460-ba0b-b7a894433ffa",
+                                                            "00674be1-08d6-4446-a4c9-06d062376a28"
+                                                        ]
+                                                    },
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Messages"
+                                                    }
                                                 },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
+                                                "widgetID": "EIAnalyticsMessageTable"
+                                            },
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 33.045383403565005,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Message Flow",
+                                            "type": "component",
+                                            "component": "EIAnalyticsMessageFlow",
+                                            "props": {
+                                                "id": "3b9157a9-dabc-4af7-9a28-e132e457ef45",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber",
+                                                            "publisher"
+                                                        ],
+                                                        "publishers": [
+                                                            "a93d734b-c943-4460-ba0b-b7a894433ffa",
+                                                            "00674be1-08d6-4446-a4c9-06d062376a28"
+                                                        ]
+                                                    },
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Message Flow"
+                                                    }
                                                 },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 66.9355350873037,
-                                        "height": 9.090802872124586,
-                                        "content": [
-                                            {
-                                                "title": "Date Time Range",
-                                                "type": "component",
-                                                "component": "DateRangePicker",
-                                                "props": {
-                                                    "id": "fb49be68-14e3-472b-b371-daf6bfef58cb",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "publisher"
-                                                            ],
-                                                            "publisherWidgetOutputs": [
-                                                                "granularity",
-                                                                "from",
-                                                                "to"
-                                                            ],
-                                                            "publishers": [
+                                                "widgetID": "EIAnalyticsMessageFlow"
+                                            },
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "height": 1964.0
+                },
+                {
+                    "id": "endpoint",
+                    "name": "Endpoint",
+                    "content": [
+                        {
+                            "type": "column",
+                            "isClosable": true,
+                            "title": "",
+                            "content": [
+                                {
+                                    "type": "row",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 14.214308430294809,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 33.11486829093233,
+                                            "height": 15.971962755248521,
+                                            "content": [
+                                                {
+                                                    "title": "EI Analytics Search Box",
+                                                    "type": "component",
+                                                    "component": "EIAnalyticsSearchBox",
+                                                    "props": {
+                                                        "id": "3865a05b-8f2e-40b3-a9a0-babbff15b622",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "publisher"
+                                                                ],
+                                                                "publisherWidgetOutputs": [
+                                                                    "selectedComponent"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "header": false
+                                                            }
+                                                        },
+                                                        "widgetID": "EIAnalyticsSearchBox"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 66.88513170906766,
+                                            "content": [
+                                                {
+                                                    "title": "Date Time Range",
+                                                    "type": "component",
+                                                    "component": "DateRangePicker",
+                                                    "props": {
+                                                        "id": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "publisher"
+                                                                ],
+                                                                "publisherWidgetOutputs": [
+                                                                    "granularity",
+                                                                    "from",
+                                                                    "to"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "defaultValue": "3 Months",
+                                                                "availableGranularities": "From Second",
+                                                                "autoSyncInterval": "10",
+                                                                "header": false
+                                                            }
+                                                        },
+                                                        "widgetID": "DateRangePicker"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 34.69254938919411,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Stats Chart",
+                                            "type": "component",
+                                            "component": "EIAnalyticsStatsChart",
+                                            "props": {
+                                                "id": "9c7f2585-8a45-46bc-9228-083354f72c46",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber"
+                                                        ],
+                                                        "publishers": [
+                                                            "3865a05b-8f2e-40b3-a9a0-babbff15b622",
+                                                            "84e1a9ea-64c0-412a-a99e-1ffb88502778"
+                                                        ],
+                                                        "widgetInputOutputMapping": [
 
-                                                            ]
-                                                        },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "defaultValue": "3 Months",
-                                                            "availableGranularities": "From Second",
-                                                            "autoSyncInterval": "10",
-                                                            "header": false
-                                                        }
+                                                        ]
                                                     },
-                                                    "widgetID": "DateRangePicker"
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Endpoint Request Count"
+                                                    }
                                                 },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 19.665088774641482,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Stats Chart",
-                                        "type": "component",
-                                        "component": "EIAnalyticsStatsChart",
-                                        "props": {
-                                            "id": "ada62cb2-563d-4240-b009-5b37592b1e96",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber"
-                                                    ],
-                                                    "publishers": [
-                                                        "fb49be68-14e3-472b-b371-daf6bfef58cb",
-                                                        "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a"
-                                                    ],
-                                                    "widgetInputOutputMapping": [
-
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-                                                    "headerTitle": "Inbound Request Count"
-                                                }
+                                                "widgetID": "EIAnalyticsStatsChart"
                                             },
-                                            "widgetID": "EIAnalyticsStatsChart"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "row",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 16.778030755110457,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "height": 10.831495131197688,
-                                        "width": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "[Inbound Endpoint Message Count]",
-                                                "type": "component",
-                                                "component": "UniversalWidget",
-                                                "props": {
-                                                    "id": "d4ece54b-c7b8-4d46-83dc-fcc097b985a9",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "subscriberWidgetInputs": [
-                                                                "timeFrom",
-                                                                "timeTo",
-                                                                "timeUnit",
-                                                                "componentName"
-                                                            ],
-                                                            "publishers": [
-                                                                "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a",
-                                                                "fb49be68-14e3-472b-b371-daf6bfef58cb"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-                                                                {
-                                                                    "subscriberWidgetInput": "timeFrom",
-                                                                    "publisherId": "fb49be68-14e3-472b-b371-daf6bfef58cb",
-                                                                    "publisherWidgetOutput": "from"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeTo",
-                                                                    "publisherId": "fb49be68-14e3-472b-b371-daf6bfef58cb",
-                                                                    "publisherWidgetOutput": "to"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeUnit",
-                                                                    "publisherId": "fb49be68-14e3-472b-b371-daf6bfef58cb",
-                                                                    "publisherWidgetOutput": "granularity"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "componentName",
-                                                                    "publisherId": "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a",
-                                                                    "publisherWidgetOutput": "selectedComponent"
-                                                                }
-                                                            ]
-                                                        },
-                                                        "isGenerated": true,
-                                                        "options": {
-                                                            "headerTitle": "Inbound Endpoint Message Count"
-                                                        }
-                                                    },
-                                                    "widgetID": "Inbound-Endpoint-Message-Count"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "[Inbound Endpoint Message Latency]",
-                                                "type": "component",
-                                                "component": "UniversalWidget",
-                                                "props": {
-                                                    "id": "0070424f-56f7-4fb4-afa5-9565963aaacb",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "subscriberWidgetInputs": [
-                                                                "timeFrom",
-                                                                "timeTo",
-                                                                "timeUnit ",
-                                                                "componentName"
-                                                            ],
-                                                            "publishers": [
-                                                                "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a",
-                                                                "fb49be68-14e3-472b-b371-daf6bfef58cb"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-                                                                {
-                                                                    "subscriberWidgetInput": "timeFrom",
-                                                                    "publisherId": "fb49be68-14e3-472b-b371-daf6bfef58cb",
-                                                                    "publisherWidgetOutput": "from"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeTo",
-                                                                    "publisherId": "fb49be68-14e3-472b-b371-daf6bfef58cb",
-                                                                    "publisherWidgetOutput": "to"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeUnit ",
-                                                                    "publisherId": "fb49be68-14e3-472b-b371-daf6bfef58cb",
-                                                                    "publisherWidgetOutput": "granularity"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "componentName",
-                                                                    "publisherId": "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a",
-                                                                    "publisherWidgetOutput": "selectedComponent"
-                                                                }
-                                                            ]
-                                                        },
-                                                        "isGenerated": true,
-                                                        "options": {
-                                                            "headerTitle": "Inbound Endpoint Message Latency"
-                                                        }
-                                                    },
-                                                    "widgetID": "Inbound-Endpoint-Message-Latency"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 18.866261040208773,
-                                "content": [
-                                    {
-                                        "title": "Messages",
-                                        "type": "component",
-                                        "component": "EIAnalyticsMessageTable",
-                                        "props": {
-                                            "id": "15cb4ed4-bc6c-4481-a773-8d37e331b544",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber"
-                                                    ],
-                                                    "publishers": [
-                                                        "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a",
-                                                        "fb49be68-14e3-472b-b371-daf6bfef58cb"
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-
-                                                }
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
                                             },
-                                            "widgetID": "EIAnalyticsMessageTable"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 36.96339393249537,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Message Flow",
-                                        "type": "component",
-                                        "component": "EIAnalyticsMessageFlow",
-                                        "props": {
-                                            "id": "744118df-2bc3-42b7-8e0f-d48c1d43ff9e",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber",
-                                                        "publisher"
-                                                    ],
-                                                    "publishers": [
-                                                        "fb49be68-14e3-472b-b371-daf6bfef58cb",
-                                                        "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a"
-                                                    ],
-                                                    "widgetInputOutputMapping": [
-
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-                                                  "headerTitle": "Message Flow"
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "row",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 22.734395675502505,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "height": 17.71053121060733,
+                                            "width": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "[Endpoint Message Count]",
+                                                    "type": "component",
+                                                    "component": "UniversalWidget",
+                                                    "props": {
+                                                        "id": "27520bf9-5470-47c5-b96c-f52244f11fc8",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "subscriberWidgetInputs": [
+                                                                    "timeFrom",
+                                                                    "timeTo",
+                                                                    "timeUnit",
+                                                                    "componentName"
+                                                                ],
+                                                                "publishers": [
+                                                                    "3865a05b-8f2e-40b3-a9a0-babbff15b622",
+                                                                    "84e1a9ea-64c0-412a-a99e-1ffb88502778"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeFrom",
+                                                                        "publisherId": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
+                                                                        "publisherWidgetOutput": "from"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeTo",
+                                                                        "publisherId": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
+                                                                        "publisherWidgetOutput": "to"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeUnit",
+                                                                        "publisherId": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
+                                                                        "publisherWidgetOutput": "granularity"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "componentName",
+                                                                        "publisherId": "3865a05b-8f2e-40b3-a9a0-babbff15b622",
+                                                                        "publisherWidgetOutput": "selectedComponent"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "isGenerated": true,
+                                                            "options": {
+                                                                "headerTitle": "Endpoint Message Count"
+                                                            }
+                                                        },
+                                                        "widgetID": "Endpoint-Message-Count"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
                                                 }
-                                            },
-                                            "widgetID": "EIAnalyticsMessageFlow"
+                                            ]
                                         },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "height": 2094.0
-            },
-            {
-                "id": "message",
-                "name": "Message",
-                "content": [
-                    {
-                        "type": "column",
-                        "isClosable": true,
-                        "title": "",
-                        "content": [
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 50.0,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Message Flow",
-                                        "type": "component",
-                                        "component": "EIAnalyticsMessageFlow",
-                                        "props": {
-                                            "id": "08da310f-e162-4b86-b06b-edaa686effb2",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber",
-                                                        "publisher"
-                                                    ]
-                                                },
-                                                "isGenerated": false,
-                                                "options": {
-                                                  "headerTitle": "Message Flow"
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "[Endpoint Message Latency]",
+                                                    "type": "component",
+                                                    "component": "UniversalWidget",
+                                                    "props": {
+                                                        "id": "e653dbfa-1f32-425e-99de-0c258d366dd9",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "subscriberWidgetInputs": [
+                                                                    "timeFrom",
+                                                                    "timeTo",
+                                                                    "timeUnit",
+                                                                    "componentName"
+                                                                ],
+                                                                "publishers": [
+                                                                    "3865a05b-8f2e-40b3-a9a0-babbff15b622",
+                                                                    "84e1a9ea-64c0-412a-a99e-1ffb88502778"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeFrom",
+                                                                        "publisherId": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
+                                                                        "publisherWidgetOutput": "from"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeTo",
+                                                                        "publisherId": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
+                                                                        "publisherWidgetOutput": "to"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeUnit",
+                                                                        "publisherId": "84e1a9ea-64c0-412a-a99e-1ffb88502778",
+                                                                        "publisherWidgetOutput": "granularity"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "componentName",
+                                                                        "publisherId": "3865a05b-8f2e-40b3-a9a0-babbff15b622",
+                                                                        "publisherWidgetOutput": "selectedComponent"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "isGenerated": true,
+                                                            "options": {
+                                                                "headerTitle": "Endpoint Message Latency"
+                                                            }
+                                                        },
+                                                        "widgetID": "Endpoint-Message-Latency"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
                                                 }
-                                            },
-                                            "widgetID": "EIAnalyticsMessageFlow"
-                                        },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "stack",
-                                "isClosable": true,
-                                "title": "",
-                                "height": 50.0,
-                                "content": [
-                                    {
-                                        "title": "EI Analytics Mediator Properties",
-                                        "type": "component",
-                                        "component": "EIAnalyticsMediatorProperties",
-                                        "props": {
-                                            "id": "a2059e30-63f8-4247-9308-92581867984a",
-                                            "configs": {
-                                                "pubsub": {
-                                                    "types": [
-                                                        "subscriber"
-                                                    ],
-                                                    "publishers": [
-                                                        "08da310f-e162-4b86-b06b-edaa686effb2"
-                                                    ]
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 28.358746505008604,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Message Table",
+                                            "type": "component",
+                                            "component": "EIAnalyticsMessageTable",
+                                            "props": {
+                                                "id": "40de7705-a760-4e1d-8554-25a04ed7dd1f",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber"
+                                                        ],
+                                                        "publishers": [
+                                                            "3865a05b-8f2e-40b3-a9a0-babbff15b622",
+                                                            "84e1a9ea-64c0-412a-a99e-1ffb88502778"
+                                                        ]
+                                                    },
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Messages"
+                                                    }
                                                 },
-                                                "isGenerated": false,
-                                                "options": {
-
+                                                "widgetID": "EIAnalyticsMessageTable"
+                                            },
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "height": 1260.7999877929688
+                },
+                {
+                    "id": "inbound",
+                    "name": "Inbound Endpoint",
+                    "content": [
+                        {
+                            "type": "column",
+                            "isClosable": true,
+                            "title": "",
+                            "content": [
+                                {
+                                    "type": "row",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 7.727225497543937,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 33.06446491269631,
+                                            "content": [
+                                                {
+                                                    "title": "EI Analytics Search Box",
+                                                    "type": "component",
+                                                    "component": "EIAnalyticsSearchBox",
+                                                    "props": {
+                                                        "id": "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "publisher"
+                                                                ],
+                                                                "publisherWidgetOutputs": [
+                                                                    "selectedComponent"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "header": false
+                                                            }
+                                                        },
+                                                        "widgetID": "EIAnalyticsSearchBox"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
                                                 }
-                                            },
-                                            "widgetID": "EIAnalyticsMediatorProperties"
+                                            ]
                                         },
-                                        "isClosable": false,
-                                        "header": {
-                                            "show": true
-                                        },
-                                        "componentName": "lm-react-component"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "height": 1374.0000305175781,
-                "hidden": true
-            },
-            {
-                "id": "mediator",
-                "name": "Mediator",
-                "content": [
-                    {
-                        "type": "row",
-                        "isClosable": true,
-                        "title": "",
-                        "height": 100.0,
-                        "content": [
-                            {
-                                "type": "column",
-                                "isClosable": true,
-                                "title": "",
-                                "width": 50.0,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "width": 50.0,
-                                        "height": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "EI Analytics Stats Chart",
-                                                "type": "component",
-                                                "component": "EIAnalyticsStatsChart",
-                                                "props": {
-                                                    "id": "277dc820-21ba-45a7-8e85-e79d7ddfccda",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 66.9355350873037,
+                                            "height": 9.090802872124586,
+                                            "content": [
+                                                {
+                                                    "title": "Date Time Range",
+                                                    "type": "component",
+                                                    "component": "DateRangePicker",
+                                                    "props": {
+                                                        "id": "fb49be68-14e3-472b-b371-daf6bfef58cb",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "publisher"
+                                                                ],
+                                                                "publisherWidgetOutputs": [
+                                                                    "granularity",
+                                                                    "from",
+                                                                    "to"
+                                                                ],
+                                                                "publishers": [
 
-                                                            ],
-                                                            "publishers": [
-                                                                "afb5839d-3770-4f79-a00a-37d4d5e5821c"
-                                                            ]
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "defaultValue": "3 Months",
+                                                                "availableGranularities": "From Second",
+                                                                "autoSyncInterval": "10",
+                                                                "header": false
+                                                            }
                                                         },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "headerTitle": "Mediator Request Count"
-                                                        }
+                                                        "widgetID": "DateRangePicker"
                                                     },
-                                                    "widgetID": "EIAnalyticsStatsChart"
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 19.665088774641482,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Stats Chart",
+                                            "type": "component",
+                                            "component": "EIAnalyticsStatsChart",
+                                            "props": {
+                                                "id": "ada62cb2-563d-4240-b009-5b37592b1e96",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber"
+                                                        ],
+                                                        "publishers": [
+                                                            "fb49be68-14e3-472b-b371-daf6bfef58cb",
+                                                            "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a"
+                                                        ],
+                                                        "widgetInputOutputMapping": [
+
+                                                        ]
+                                                    },
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Inbound Request Count"
+                                                    }
                                                 },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "height": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "[Mediator Message Count]",
-                                                "type": "component",
-                                                "component": "UniversalWidget",
-                                                "props": {
-                                                    "id": "c103ef9b-4216-424a-a1fd-415ba0329edb",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "subscriberWidgetInputs": [
-                                                                "timeFrom",
-                                                                "timeTo",
-                                                                "timeUnit"
-                                                            ],
-                                                            "publishers": [
-                                                                "afb5839d-3770-4f79-a00a-37d4d5e5821c"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-                                                                {
-                                                                    "subscriberWidgetInput": "timeFrom",
-                                                                    "publisherId": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
-                                                                    "publisherWidgetOutput": "from"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeTo",
-                                                                    "publisherId": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
-                                                                    "publisherWidgetOutput": "to"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeUnit",
-                                                                    "publisherId": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
-                                                                    "publisherWidgetOutput": "granularity"
-                                                                }
-                                                            ]
+                                                "widgetID": "EIAnalyticsStatsChart"
+                                            },
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "row",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 16.778030755110457,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "height": 10.831495131197688,
+                                            "width": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "[Inbound Endpoint Message Count]",
+                                                    "type": "component",
+                                                    "component": "UniversalWidget",
+                                                    "props": {
+                                                        "id": "d4ece54b-c7b8-4d46-83dc-fcc097b985a9",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "subscriberWidgetInputs": [
+                                                                    "timeFrom",
+                                                                    "timeTo",
+                                                                    "timeUnit",
+                                                                    "componentName"
+                                                                ],
+                                                                "publishers": [
+                                                                    "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a",
+                                                                    "fb49be68-14e3-472b-b371-daf6bfef58cb"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeFrom",
+                                                                        "publisherId": "fb49be68-14e3-472b-b371-daf6bfef58cb",
+                                                                        "publisherWidgetOutput": "from"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeTo",
+                                                                        "publisherId": "fb49be68-14e3-472b-b371-daf6bfef58cb",
+                                                                        "publisherWidgetOutput": "to"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeUnit",
+                                                                        "publisherId": "fb49be68-14e3-472b-b371-daf6bfef58cb",
+                                                                        "publisherWidgetOutput": "granularity"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "componentName",
+                                                                        "publisherId": "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a",
+                                                                        "publisherWidgetOutput": "selectedComponent"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "isGenerated": true,
+                                                            "options": {
+                                                                "headerTitle": "Inbound Endpoint Message Count"
+                                                            }
                                                         },
-                                                        "isGenerated": true,
-                                                        "options": {
-                                                            "headerTitle": "Mediator Message Count"
-                                                        }
+                                                        "widgetID": "Inbound-Endpoint-Message-Count"
                                                     },
-                                                    "widgetID": "Mediator-Message-Count"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "column",
-                                "isClosable": true,
-                                "title": "",
-                                "width": 50.0,
-                                "content": [
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "height": 50.0,
-                                        "width": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "Date Time Range",
-                                                "type": "component",
-                                                "component": "DateRangePicker",
-                                                "props": {
-                                                    "id": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "publisher"
-                                                            ],
-                                                            "publisherWidgetOutputs": [
-                                                                "granularity",
-                                                                "from",
-                                                                "to"
-                                                            ]
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "[Inbound Endpoint Message Latency]",
+                                                    "type": "component",
+                                                    "component": "UniversalWidget",
+                                                    "props": {
+                                                        "id": "0070424f-56f7-4fb4-afa5-9565963aaacb",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "subscriberWidgetInputs": [
+                                                                    "timeFrom",
+                                                                    "timeTo",
+                                                                    "timeUnit ",
+                                                                    "componentName"
+                                                                ],
+                                                                "publishers": [
+                                                                    "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a",
+                                                                    "fb49be68-14e3-472b-b371-daf6bfef58cb"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeFrom",
+                                                                        "publisherId": "fb49be68-14e3-472b-b371-daf6bfef58cb",
+                                                                        "publisherWidgetOutput": "from"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeTo",
+                                                                        "publisherId": "fb49be68-14e3-472b-b371-daf6bfef58cb",
+                                                                        "publisherWidgetOutput": "to"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeUnit ",
+                                                                        "publisherId": "fb49be68-14e3-472b-b371-daf6bfef58cb",
+                                                                        "publisherWidgetOutput": "granularity"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "componentName",
+                                                                        "publisherId": "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a",
+                                                                        "publisherWidgetOutput": "selectedComponent"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "isGenerated": true,
+                                                            "options": {
+                                                                "headerTitle": "Inbound Endpoint Message Latency"
+                                                            }
                                                         },
-                                                        "isGenerated": false,
-                                                        "options": {
-                                                            "defaultValue": "3 Months",
-                                                            "availableGranularities": "From Second",
-                                                            "autoSyncInterval": "10",
-                                                            "header": false
-                                                        }
+                                                        "widgetID": "Inbound-Endpoint-Message-Latency"
                                                     },
-                                                    "widgetID": "DateRangePicker"
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 18.866261040208773,
+                                    "content": [
+                                        {
+                                            "title": "Messages",
+                                            "type": "component",
+                                            "component": "EIAnalyticsMessageTable",
+                                            "props": {
+                                                "id": "15cb4ed4-bc6c-4481-a773-8d37e331b544",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber"
+                                                        ],
+                                                        "publishers": [
+                                                            "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a",
+                                                            "fb49be68-14e3-472b-b371-daf6bfef58cb"
+                                                        ]
+                                                    },
+                                                    "isGenerated": false,
+                                                    "options": {
+
+                                                    }
                                                 },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
+                                                "widgetID": "EIAnalyticsMessageTable"
+                                            },
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 36.96339393249537,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Message Flow",
+                                            "type": "component",
+                                            "component": "EIAnalyticsMessageFlow",
+                                            "props": {
+                                                "id": "744118df-2bc3-42b7-8e0f-d48c1d43ff9e",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber",
+                                                            "publisher"
+                                                        ],
+                                                        "publishers": [
+                                                            "fb49be68-14e3-472b-b371-daf6bfef58cb",
+                                                            "5ecd9b9d-08c6-4de9-9cb7-c18e74892b6a"
+                                                        ],
+                                                        "widgetInputOutputMapping": [
+
+                                                        ]
+                                                    },
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Message Flow"
+                                                    }
                                                 },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "stack",
-                                        "isClosable": true,
-                                        "title": "",
-                                        "height": 50.0,
-                                        "content": [
-                                            {
-                                                "title": "[Mediator Message Latency]",
-                                                "type": "component",
-                                                "component": "UniversalWidget",
-                                                "props": {
-                                                    "id": "c3ce4687-c66e-45e6-9b7e-175c133f7437",
-                                                    "configs": {
-                                                        "pubsub": {
-                                                            "types": [
-                                                                "subscriber"
-                                                            ],
-                                                            "subscriberWidgetInputs": [
-                                                                "timeFrom ",
-                                                                "timeTo",
-                                                                "timeUnit"
-                                                            ],
-                                                            "publishers": [
-                                                                "afb5839d-3770-4f79-a00a-37d4d5e5821c"
-                                                            ],
-                                                            "widgetInputOutputMapping": [
-                                                                {
-                                                                    "subscriberWidgetInput": "timeFrom ",
-                                                                    "publisherId": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
-                                                                    "publisherWidgetOutput": "from"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeTo",
-                                                                    "publisherId": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
-                                                                    "publisherWidgetOutput": "to"
-                                                                },
-                                                                {
-                                                                    "subscriberWidgetInput": "timeUnit",
-                                                                    "publisherId": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
-                                                                    "publisherWidgetOutput": "granularity"
-                                                                }
-                                                            ]
+                                                "widgetID": "EIAnalyticsMessageFlow"
+                                            },
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "height": 2094.0
+                },
+                {
+                    "id": "message",
+                    "name": "Message",
+                    "content": [
+                        {
+                            "type": "column",
+                            "isClosable": true,
+                            "title": "",
+                            "content": [
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 50.0,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Message Flow",
+                                            "type": "component",
+                                            "component": "EIAnalyticsMessageFlow",
+                                            "props": {
+                                                "id": "08da310f-e162-4b86-b06b-edaa686effb2",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber",
+                                                            "publisher"
+                                                        ]
+                                                    },
+                                                    "isGenerated": false,
+                                                    "options": {
+                                                        "headerTitle": "Message Flow"
+                                                    }
+                                                },
+                                                "widgetID": "EIAnalyticsMessageFlow"
+                                            },
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "stack",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "height": 50.0,
+                                    "content": [
+                                        {
+                                            "title": "EI Analytics Mediator Properties",
+                                            "type": "component",
+                                            "component": "EIAnalyticsMediatorProperties",
+                                            "props": {
+                                                "id": "a2059e30-63f8-4247-9308-92581867984a",
+                                                "configs": {
+                                                    "pubsub": {
+                                                        "types": [
+                                                            "subscriber"
+                                                        ],
+                                                        "publishers": [
+                                                            "08da310f-e162-4b86-b06b-edaa686effb2"
+                                                        ]
+                                                    },
+                                                    "isGenerated": false,
+                                                    "options": {
+
+                                                    }
+                                                },
+                                                "widgetID": "EIAnalyticsMediatorProperties"
+                                            },
+                                            "isClosable": false,
+                                            "header": {
+                                                "show": true
+                                            },
+                                            "componentName": "lm-react-component"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "height": 1374.0000305175781,
+                    "hidden": true
+                },
+                {
+                    "id": "mediator",
+                    "name": "Mediator",
+                    "content": [
+                        {
+                            "type": "row",
+                            "isClosable": true,
+                            "title": "",
+                            "height": 100.0,
+                            "content": [
+                                {
+                                    "type": "column",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "width": 50.0,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "width": 50.0,
+                                            "height": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "EI Analytics Stats Chart",
+                                                    "type": "component",
+                                                    "component": "EIAnalyticsStatsChart",
+                                                    "props": {
+                                                        "id": "277dc820-21ba-45a7-8e85-e79d7ddfccda",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+
+                                                                ],
+                                                                "publishers": [
+                                                                    "afb5839d-3770-4f79-a00a-37d4d5e5821c"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "headerTitle": "Mediator Request Count"
+                                                            }
                                                         },
-                                                        "isGenerated": true,
-                                                        "options": {
-                                                            "headerTitle": "Mediator Message Latency"
-                                                        }
+                                                        "widgetID": "EIAnalyticsStatsChart"
                                                     },
-                                                    "widgetID": "Mediator-Message-Latency"
-                                                },
-                                                "isClosable": false,
-                                                "header": {
-                                                    "show": true
-                                                },
-                                                "componentName": "lm-react-component"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "hidden": true
-            }
-        ],
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "height": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "[Mediator Message Count]",
+                                                    "type": "component",
+                                                    "component": "UniversalWidget",
+                                                    "props": {
+                                                        "id": "c103ef9b-4216-424a-a1fd-415ba0329edb",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "subscriberWidgetInputs": [
+                                                                    "timeFrom",
+                                                                    "timeTo",
+                                                                    "timeUnit"
+                                                                ],
+                                                                "publishers": [
+                                                                    "afb5839d-3770-4f79-a00a-37d4d5e5821c"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeFrom",
+                                                                        "publisherId": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
+                                                                        "publisherWidgetOutput": "from"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeTo",
+                                                                        "publisherId": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
+                                                                        "publisherWidgetOutput": "to"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeUnit",
+                                                                        "publisherId": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
+                                                                        "publisherWidgetOutput": "granularity"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "isGenerated": true,
+                                                            "options": {
+                                                                "headerTitle": "Mediator Message Count"
+                                                            }
+                                                        },
+                                                        "widgetID": "Mediator-Message-Count"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "column",
+                                    "isClosable": true,
+                                    "title": "",
+                                    "width": 50.0,
+                                    "content": [
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "height": 50.0,
+                                            "width": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "Date Time Range",
+                                                    "type": "component",
+                                                    "component": "DateRangePicker",
+                                                    "props": {
+                                                        "id": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "publisher"
+                                                                ],
+                                                                "publisherWidgetOutputs": [
+                                                                    "granularity",
+                                                                    "from",
+                                                                    "to"
+                                                                ]
+                                                            },
+                                                            "isGenerated": false,
+                                                            "options": {
+                                                                "defaultValue": "3 Months",
+                                                                "availableGranularities": "From Second",
+                                                                "autoSyncInterval": "10",
+                                                                "header": false
+                                                            }
+                                                        },
+                                                        "widgetID": "DateRangePicker"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "stack",
+                                            "isClosable": true,
+                                            "title": "",
+                                            "height": 50.0,
+                                            "content": [
+                                                {
+                                                    "title": "[Mediator Message Latency]",
+                                                    "type": "component",
+                                                    "component": "UniversalWidget",
+                                                    "props": {
+                                                        "id": "c3ce4687-c66e-45e6-9b7e-175c133f7437",
+                                                        "configs": {
+                                                            "pubsub": {
+                                                                "types": [
+                                                                    "subscriber"
+                                                                ],
+                                                                "subscriberWidgetInputs": [
+                                                                    "timeFrom ",
+                                                                    "timeTo",
+                                                                    "timeUnit"
+                                                                ],
+                                                                "publishers": [
+                                                                    "afb5839d-3770-4f79-a00a-37d4d5e5821c"
+                                                                ],
+                                                                "widgetInputOutputMapping": [
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeFrom ",
+                                                                        "publisherId": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
+                                                                        "publisherWidgetOutput": "from"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeTo",
+                                                                        "publisherId": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
+                                                                        "publisherWidgetOutput": "to"
+                                                                    },
+                                                                    {
+                                                                        "subscriberWidgetInput": "timeUnit",
+                                                                        "publisherId": "afb5839d-3770-4f79-a00a-37d4d5e5821c",
+                                                                        "publisherWidgetOutput": "granularity"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "isGenerated": true,
+                                                            "options": {
+                                                                "headerTitle": "Mediator Message Latency"
+                                                            }
+                                                        },
+                                                        "widgetID": "Mediator-Message-Latency"
+                                                    },
+                                                    "isClosable": false,
+                                                    "header": {
+                                                        "show": true
+                                                    },
+                                                    "componentName": "lm-react-component"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "hidden": true
+                }
+            ]
+        },
         "hasOwnerPermission": false,
         "hasDesignerPermission": false,
         "hasViewerPermission": false


### PR DESCRIPTION
## Purpose
> Currently tenantId is hard coded as "-1234" in all the widgets. Tenant ID has to be read from the dashboard properties. We have changed dashboard JSON structure inorder to achive this.
The change in the common dashboard JSON structure was done in https://github.com/wso2/carbon-dashboards/pull/1144

## Goals
> Edit EI Dashboard JSON to add tenantId as a dashboard property
> Use tenantId from dashboard properties instead of hard coded tenantId in all widgets

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
