### PR TITLE
Revert use of inmemory config tables in apps that does not have high TPS

### DIFF
--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/email-notification-siddhi-file/APIM_ALERT_EMAIL_NOTIFICATION.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/email-notification-siddhi-file/APIM_ALERT_EMAIL_NOTIFICATION.siddhi
@@ -17,17 +17,6 @@
 @App:name("APIM_ALERT_EMAIL_NOTIFICATION")
 @App:description('Send email to all the subscribers of a particular alert') 
 
-define trigger LoadInMemoryTable at 'start';
-
-@source(type = 'inMemory' , topic = 'AlertStakeholderInfoStream')
-define stream AlertStakeholderInfoStream (
- userId string,
- alertTypes string,
- emails string,
- isSubscriber bool,
- isPublisher bool,
- isAdmin bool);
-
 @source(type = "inMemory", topic = "AbnormalBackendTimeAlertStream")
 define stream AbnormalBackendTimeAlertStream( apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, apiResourceTemplate string, apiMethod string, backendTime long, thresholdBackendTime long, message string, severity int, alertTimestamp long);
 
@@ -60,41 +49,38 @@ define stream EmailNotificationStream (
 @PrimaryKey('userId', 'isSubscriber', 'isPublisher', 'isAdmin')
 define table ApimAlertStakeholderInfo(userId string, alertTypes string, emails string, isSubscriber bool, isPublisher bool, isAdmin bool);
 
-@PrimaryKey('userId', 'isSubscriber', 'isPublisher', 'isAdmin')
-define table ApimAlertStakeholderInfoInMemory(userId string, alertTypes string, emails string, isSubscriber bool, isPublisher bool, isAdmin bool);
-
 @info(name = 'AbnormalBackendTimeAlert customise Email body')
-from AbnormalBackendTimeAlertStream#window.length(1) as A join ApimAlertStakeholderInfoInMemory as S
+from AbnormalBackendTimeAlertStream#window.length(1) as A join ApimAlertStakeholderInfo as S
 	on ((A.apiCreator == S.userId and true == S.isPublisher ) or true == S.isAdmin ) and str:contains(S.alertTypes, 'AbnormalBackendTime')
 select 'AbnormalBackendTime' as type , str:concat('Abnormal backend time detected for http ', A.apiMethod, ' method of resource template:', A.apiResourceTemplate, ' in api:', A.apiName, ' of tenant domain:', A.apiCreatorTenantDomain, ', threshold value:', A.thresholdBackendTime, 'ms.') as message, time:dateFormat(A.alertTimestamp, 'yyyy-MM-dd HH:mm:ss') as alertTimestamp, S.emails
 insert into EmailAlertStream;
 
 @info(name = 'AbnormalRequestsCountAlertStream customise Email body')
-from AbnormalRequestsCountAlertStream#window.length(1) as A join ApimAlertStakeholderInfoInMemory as S
+from AbnormalRequestsCountAlertStream#window.length(1) as A join ApimAlertStakeholderInfo as S
 	on ((A.applicationOwner == S.userId and true == S.isSubscriber ) or true == S.isAdmin ) and str:contains(S.alertTypes, 'AbnormalRequestsPerMin')
 select 'AbnormalRequestsPerMin' as type , str:concat('Abnormal request count detected during last minute using application ', A.applicationName, ' owned by ', A.applicationOwner, ' for api :', A.apiName, ', abnormal request count:', A.requestCountPerMin, ".") as message, time:dateFormat(A.alertTimestamp, 'yyyy-MM-dd HH:mm:ss') as alertTimestamp, S.emails
 insert into EmailAlertStream;
 
 @info(name = 'RequestPatternChangedAlertStream customise Email body')
-from RequestPatternChangedAlertStream#window.length(1) as A join ApimAlertStakeholderInfoInMemory as S
+from RequestPatternChangedAlertStream#window.length(1) as A join ApimAlertStakeholderInfo as S
 	on ((A.applicationOwner == S.userId and true == S.isSubscriber ) or true == S.isAdmin ) and str:contains(S.alertTypes, 'AbnormalRequestPattern')
 select 'AbnormalRequestPattern' as type , str:concat(A.message, ' by user :', A.username, ' using application : ', A.applicationName, ' owned by: ', A.applicationOwner, '.') as message, time:dateFormat(A.alertTimestamp, 'yyyy-MM-dd HH:mm:ss') as alertTimestamp, S.emails
 insert into EmailAlertStream;
 
 @info(name = 'AbnormalResponseTimeAlertStream customise Email body')
-from AbnormalResponseTimeAlertStream#window.length(1) as A join ApimAlertStakeholderInfoInMemory as S
+from AbnormalResponseTimeAlertStream#window.length(1) as A join ApimAlertStakeholderInfo as S
 	on ((A.apiCreator == S.userId and true == S.isPublisher ) or true == S.isAdmin) and str:contains(S.alertTypes, 'AbnormalResponseTime')
 select 'AbnormalResponseTime' as type , str:concat('Abnormal response time detected for http ', A.apiMethod, ' method of resource template:', A.apiResourceTemplate, ' in api:', A.apiName, ' of tenant domain:', A.apiCreatorTenantDomain, ', threshold value:', A.thresholdResponseTime, 'ms.') as message, time:dateFormat(A.alertTimestamp, 'yyyy-MM-dd HH:mm:ss') as alertTimestamp, S.emails
 insert into EmailAlertStream;
 
 @info(name = 'ApiHealthMonitorAlertStream customise Email body')
-from ApiHealthMonitorAlertStream#window.length(1) as A join ApimAlertStakeholderInfoInMemory as S
+from ApiHealthMonitorAlertStream#window.length(1) as A  join ApimAlertStakeholderInfo as S
 	on ((A.apiCreator == S.userId and true == S.isPublisher ) or true == S.isAdmin ) and str:contains(S.alertTypes, 'ApiHealthMonitor')
 select 'ApiHealthMonitor' as type, str:concat('API:', apiName, ' ', apiVersion, '-', message) as message, time:dateFormat(A.alertTimestamp, 'yyyy-MM-dd HH:mm:ss') as alertTimestamp, S.emails
 insert into EmailAlertStream;
 
 @info(name = 'TierLimitHittingAlertStream customise Email body')
-from TierLimitHittingAlertStream#window.length(1) as A join ApimAlertStakeholderInfoInMemory as S
+from TierLimitHittingAlertStream#window.length(1) as A join ApimAlertStakeholderInfo as S
 	on ((A.subscriber == S.userId and true == S.isSubscriber ) or true == S.isAdmin ) and str:contains(S.alertTypes, 'FrequentTierLimitHitting')
 select 'FrequentTierLimitHitting' as type ,
 ifThenElse(str:contains(A.message, 'Application frequently goes beyond the allocated quota'), str:concat("The application ", A.applicationName, " owned by ", A.subscriber, " frequently goes beyond the allocated quota when accessing the ", A.apiName, " API."),
@@ -102,7 +88,7 @@ str:concat(A.message , " Using the ", A.applicationName, " application owned by 
 insert into EmailAlertStream;
 
 @info(name = 'IpAccessAbnormalityAlertStream customise Email body')
-from IpAccessAbnormalityAlertStream#window.length(1) AS A join ApimAlertStakeholderInfoInMemory as S
+from IpAccessAbnormalityAlertStream#window.length(1) as A join ApimAlertStakeholderInfo as S
 	on ((A.applicationOwner == S.userId and true == S.isSubscriber ) or true == S.isAdmin ) and str:contains(S.alertTypes, 'UnusualIPAccess')
 select 'UnusualIPAccess' as type , str:concat("A request from a ", ifThenElse(str:contains(message, 'old'), 'old', 'new'), " IP (", ip, ") detected by user:" , A.username, " using application:", applicationName, " owned by ", applicationOwner, ".") as message, time:dateFormat(A.alertTimestamp, 'yyyy-MM-dd HH:mm:ss') as alertTimestamp, S.emails
 insert into EmailAlertStream;
@@ -111,23 +97,3 @@ insert into EmailAlertStream;
 from EmailAlertStream
 select *
 insert into EmailNotificationStream;
-
--- Update the AlertCreatorConfig Table @ start
-@info(name = 'Load ApimAlertStakeholderInfoInMemory at deployment')
-from LoadInMemoryTable join ApimAlertStakeholderInfo
-select userId, alertTypes, emails, isSubscriber, isPublisher, isAdmin
-update or
-insert into ApimAlertStakeholderInfoInMemory
-set ApimAlertStakeholderInfoInMemory.alertTypes = alertTypes, ApimAlertStakeholderInfoInMemory.emails = emails
-	on ApimAlertStakeholderInfoInMemory.userId == userId and ApimAlertStakeholderInfoInMemory.isPublisher == isPublisher and
- ApimAlertStakeholderInfoInMemory.isSubscriber == isSubscriber and ApimAlertStakeholderInfoInMemory.isAdmin == isAdmin;
-
--- Data updating logic
-@info(name = 'Runtime update of configuration table')
-from AlertStakeholderInfoStream
-select userId, alertTypes, emails, isSubscriber, isPublisher, isAdmin
-update or
-insert into ApimAlertStakeholderInfoInMemory
-set ApimAlertStakeholderInfoInMemory.alertTypes = alertTypes, ApimAlertStakeholderInfoInMemory.emails = emails
-	on ApimAlertStakeholderInfoInMemory.userId == userId and ApimAlertStakeholderInfoInMemory.isPublisher == isPublisher and
- ApimAlertStakeholderInfoInMemory.isSubscriber == isSubscriber and ApimAlertStakeholderInfoInMemory.isAdmin == isAdmin;

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_abnormal_request_count_0.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_abnormal_request_count_0.siddhi
@@ -17,19 +17,10 @@
 @App:name("apim_alert_abnormal_request_count_0")
 @App:description("Identifies the API requests with abnormal request count per minute and add to AllAlertStream and AbnormalRequestCountAlertStream")
 
-define trigger LoadInMemoryTable at 'start';
 define trigger MinTriggerEventStream at every 1 minute;
 
 -- This stream definition is only to define the Aggregation. It does not consume the actual API request.
 define stream Request (meta_clientType string, applicationConsumerKey string, applicationName string, applicationId string, applicationOwner string, apiContext string,apiName string, apiVersion string, apiResourcePath string, apiResourceTemplate string, apiMethod string, apiCreator string, apiCreatorTenantDomain string, apiTier string, apiHostname string, username string, userTenantDomain string, userIp string, userAgent string, requestTimestamp long, throttledOut bool, responseTime long, serviceTime long, backendTime long, responseCacheHit bool, responseSize long, protocol string, responseCode int, destination string, securityLatency long, throttlingLatency long, requestMedLat long, responseMedLat long, backendLatency long, otherLatency long, gatewayType string, label string);
-
-@source(type = 'inMemory' , topic = 'ApiSubscriberAlertConfigurationStream')
-define stream ApiSubscriberAlertConfigurationStream (
- applicationId string,
- subscriber string,
- apiName string,
- apiVersion string,
- thresholdRequestCountPerMin int);
 
 define stream SuppressedAbnormalRequestsCountStream(applicationName string, applicationOwner string, tenantDomain string, apiName string, apiVersion string, requestCountPerMin long, thresholdRequestCountPerMin int);
 
@@ -39,9 +30,6 @@ define stream AbnormalRequestsCountAlertStream(applicationName string, applicati
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
 @PrimaryKey('applicationId', 'apiName', 'apiVersion')
 define table ApiSubAlertConf (applicationId string, subscriber string, apiName string, apiVersion string, thresholdRequestCountPerMin int);
-
-@PrimaryKey('applicationId', 'apiName', 'apiVersion')
-define table ApiSubAlertConfInMemory (applicationId string, apiName string, apiVersion string, thresholdRequestCountPerMin int);
 
 -- This aggregation definition is only for retrieving data. No data is actually aggregated from this.
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
@@ -72,18 +60,13 @@ select apiName, apiVersion, applicationId, applicationName, applicationOwner, us
 insert current events into RequestsPerMinStream;
 
 @info(name = 'configurationInfoRetrieveQuery')
-from RequestsPerMinStream as R join ApiSubAlertConfInMemory as T
-	on ( R.applicationId == T.applicationId and R.apiName == T.apiName and R.apiVersion == T.apiVersion)
+from RequestsPerMinStream as R join ApiSubAlertConf as T
+	on ( R.applicationId == T.applicationId and R.apiName == T.apiName and R.apiVersion == T.apiVersion and T.thresholdRequestCountPerMin > 0 and R.requestCountPerMin > T.thresholdRequestCountPerMin)
 select R.applicationName, R.applicationOwner, R.tenantDomain, R.apiName, R.apiVersion, R.requestCountPerMin, T.thresholdRequestCountPerMin
 insert into AbnormalRequestsPerMinAlertStreamTemp;
 
-@info(name = 'FilterForAlerting')
-from AbnormalRequestsPerMinAlertStreamTemp[ requestCountPerMin > thresholdRequestCountPerMin ]
-select *
-insert into AbnormalRequestsPerMinAlertStreamTemp2;
-
 @info(name = 'Alert Suppression')
-from AbnormalRequestsPerMinAlertStreamTemp2#window.length(1) as a left outer join SuppressedAbnormalRequestsCountStream#window.time(10 minute) as b
+from AbnormalRequestsPerMinAlertStreamTemp#window.length(1) as a left outer join SuppressedAbnormalRequestsCountStream#window.time(10 minute) as b
 	on (a.applicationName == b.applicationName and a.applicationOwner == b.applicationOwner and a.tenantDomain == b.tenantDomain and
  a.apiName == b.apiName and a.apiVersion == b.apiVersion)
 select a.applicationName, a.applicationOwner, a.tenantDomain, a.apiName, a.apiVersion, a.requestCountPerMin, a.thresholdRequestCountPerMin
@@ -94,28 +77,3 @@ insert into SuppressedAbnormalRequestsCountStream;
 from SuppressedAbnormalRequestsCountStream
 select applicationName, applicationOwner, tenantDomain, apiName, apiVersion, requestCountPerMin, thresholdRequestCountPerMin, 'Abnormal request count detected during last minute.' as message , 2 as severity, (time:timestampInMilliseconds()) as alertTimestamp
 insert into AbnormalRequestsCountAlertStream;
-
--- Update the ApiSubAlertConf Table @ start
-@info(name = 'Load ApiSubAlertConfInMemory')
-from LoadInMemoryTable join ApiSubAlertConf
- 	on thresholdRequestCountPerMin > 0
-select applicationId, apiName, apiVersion, thresholdRequestCountPerMin
-update or
-insert into ApiSubAlertConfInMemory
-set ApiSubAlertConfInMemory.thresholdRequestCountPerMin = thresholdRequestCountPerMin
-	on ApiSubAlertConfInMemory.applicationId == applicationId and ApiSubAlertConfInMemory.apiName == apiName and ApiSubAlertConfInMemory.apiVersion == apiVersion;
-
--- Update ApiSubAlertConf table if receive event form APIM
-@info(name = 'Update ApiSubAlertConfInMemory')
-from ApiSubscriberAlertConfigurationStream[thresholdRequestCountPerMin > 0]
-select applicationId, apiName, apiVersion, thresholdRequestCountPerMin
-update or
-insert into ApiSubAlertConfInMemory
-set ApiSubAlertConfInMemory.thresholdRequestCountPerMin = thresholdRequestCountPerMin
-	on ApiSubAlertConfInMemory.applicationId == applicationId and ApiSubAlertConfInMemory.apiName == apiName and ApiSubAlertConfInMemory.apiVersion == apiVersion;
-
-@info(name = 'Delete ApiSubAlertConfInMemory when config is 0')
-from ApiSubscriberAlertConfigurationStream[thresholdRequestCountPerMin == 0]
-select applicationId, apiName, apiVersion, thresholdRequestCountPerMin
-delete  ApiSubAlertConfInMemory
-	on ApiSubAlertConfInMemory.applicationId == applicationId and ApiSubAlertConfInMemory.apiName == apiName and ApiSubAlertConfInMemory.apiVersion == apiVersion;


### PR DESCRIPTION
## Purpose
$subject

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes