### PR TITLE
[APIM Analytics] Periodically sync in-memory configuration tables

### DIFF
--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/email-notification-siddhi-file/APIM_ALERT_EMAIL_NOTIFICATION.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/email-notification-siddhi-file/APIM_ALERT_EMAIL_NOTIFICATION.siddhi
@@ -17,17 +17,6 @@
 @App:name("APIM_ALERT_EMAIL_NOTIFICATION")
 @App:description('Send email to all the subscribers of a particular alert') 
 
-define trigger LoadInMemoryTable at 'start';
-
-@source(type = 'inMemory' , topic = 'AlertStakeholderInfoStream')
-define stream AlertStakeholderInfoStream (
- userId string,
- alertTypes string,
- emails string,
- isSubscriber bool,
- isPublisher bool,
- isAdmin bool);
-
 @source(type = "inMemory", topic = "AbnormalBackendTimeAlertStream")
 define stream AbnormalBackendTimeAlertStream( apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, apiResourceTemplate string, apiMethod string, backendTime long, thresholdBackendTime long, message string, severity int, alertTimestamp long);
 
@@ -58,43 +47,41 @@ define stream EmailNotificationStream (
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
 @PrimaryKey('userId', 'isSubscriber', 'isPublisher', 'isAdmin')
+@index('userId', 'isPublisher', 'isAdmin' , 'alertTypes') 
 define table ApimAlertStakeholderInfo(userId string, alertTypes string, emails string, isSubscriber bool, isPublisher bool, isAdmin bool);
 
-@PrimaryKey('userId', 'isSubscriber', 'isPublisher', 'isAdmin')
-define table ApimAlertStakeholderInfoInMemory(userId string, alertTypes string, emails string, isSubscriber bool, isPublisher bool, isAdmin bool);
-
 @info(name = 'AbnormalBackendTimeAlert customise Email body')
-from AbnormalBackendTimeAlertStream#window.length(1) as A join ApimAlertStakeholderInfoInMemory as S
+from AbnormalBackendTimeAlertStream#window.length(1) as A join ApimAlertStakeholderInfo as S
 	on ((A.apiCreator == S.userId and true == S.isPublisher ) or true == S.isAdmin ) and str:contains(S.alertTypes, 'AbnormalBackendTime')
 select 'AbnormalBackendTime' as type , str:concat('Abnormal backend time detected for http ', A.apiMethod, ' method of resource template:', A.apiResourceTemplate, ' in api:', A.apiName, ' of tenant domain:', A.apiCreatorTenantDomain, ', threshold value:', A.thresholdBackendTime, 'ms.') as message, time:dateFormat(A.alertTimestamp, 'yyyy-MM-dd HH:mm:ss') as alertTimestamp, S.emails
 insert into EmailAlertStream;
 
 @info(name = 'AbnormalRequestsCountAlertStream customise Email body')
-from AbnormalRequestsCountAlertStream#window.length(1) as A join ApimAlertStakeholderInfoInMemory as S
+from AbnormalRequestsCountAlertStream#window.length(1) as A join ApimAlertStakeholderInfo as S
 	on ((A.applicationOwner == S.userId and true == S.isSubscriber ) or true == S.isAdmin ) and str:contains(S.alertTypes, 'AbnormalRequestsPerMin')
 select 'AbnormalRequestsPerMin' as type , str:concat('Abnormal request count detected during last minute using application ', A.applicationName, ' owned by ', A.applicationOwner, ' for api :', A.apiName, ', abnormal request count:', A.requestCountPerMin, ".") as message, time:dateFormat(A.alertTimestamp, 'yyyy-MM-dd HH:mm:ss') as alertTimestamp, S.emails
 insert into EmailAlertStream;
 
 @info(name = 'RequestPatternChangedAlertStream customise Email body')
-from RequestPatternChangedAlertStream#window.length(1) as A join ApimAlertStakeholderInfoInMemory as S
+from RequestPatternChangedAlertStream#window.length(1) as A join ApimAlertStakeholderInfo as S
 	on ((A.applicationOwner == S.userId and true == S.isSubscriber ) or true == S.isAdmin ) and str:contains(S.alertTypes, 'AbnormalRequestPattern')
 select 'AbnormalRequestPattern' as type , str:concat(A.message, ' by user :', A.username, ' using application : ', A.applicationName, ' owned by: ', A.applicationOwner, '.') as message, time:dateFormat(A.alertTimestamp, 'yyyy-MM-dd HH:mm:ss') as alertTimestamp, S.emails
 insert into EmailAlertStream;
 
 @info(name = 'AbnormalResponseTimeAlertStream customise Email body')
-from AbnormalResponseTimeAlertStream#window.length(1) as A join ApimAlertStakeholderInfoInMemory as S
+from AbnormalResponseTimeAlertStream#window.length(1) as A join ApimAlertStakeholderInfo as S
 	on ((A.apiCreator == S.userId and true == S.isPublisher ) or true == S.isAdmin) and str:contains(S.alertTypes, 'AbnormalResponseTime')
 select 'AbnormalResponseTime' as type , str:concat('Abnormal response time detected for http ', A.apiMethod, ' method of resource template:', A.apiResourceTemplate, ' in api:', A.apiName, ' of tenant domain:', A.apiCreatorTenantDomain, ', threshold value:', A.thresholdResponseTime, 'ms.') as message, time:dateFormat(A.alertTimestamp, 'yyyy-MM-dd HH:mm:ss') as alertTimestamp, S.emails
 insert into EmailAlertStream;
 
 @info(name = 'ApiHealthMonitorAlertStream customise Email body')
-from ApiHealthMonitorAlertStream#window.length(1) as A join ApimAlertStakeholderInfoInMemory as S
+from ApiHealthMonitorAlertStream#window.length(1) as A join ApimAlertStakeholderInfo as S
 	on ((A.apiCreator == S.userId and true == S.isPublisher ) or true == S.isAdmin ) and str:contains(S.alertTypes, 'ApiHealthMonitor')
 select 'ApiHealthMonitor' as type, str:concat('API:', apiName, ' ', apiVersion, '-', message) as message, time:dateFormat(A.alertTimestamp, 'yyyy-MM-dd HH:mm:ss') as alertTimestamp, S.emails
 insert into EmailAlertStream;
 
 @info(name = 'TierLimitHittingAlertStream customise Email body')
-from TierLimitHittingAlertStream#window.length(1) as A join ApimAlertStakeholderInfoInMemory as S
+from TierLimitHittingAlertStream#window.length(1) as A join ApimAlertStakeholderInfo as S
 	on ((A.subscriber == S.userId and true == S.isSubscriber ) or true == S.isAdmin ) and str:contains(S.alertTypes, 'FrequentTierLimitHitting')
 select 'FrequentTierLimitHitting' as type ,
 ifThenElse(str:contains(A.message, 'Application frequently goes beyond the allocated quota'), str:concat("The application ", A.applicationName, " owned by ", A.subscriber, " frequently goes beyond the allocated quota when accessing the ", A.apiName, " API."),
@@ -102,7 +89,7 @@ str:concat(A.message , " Using the ", A.applicationName, " application owned by 
 insert into EmailAlertStream;
 
 @info(name = 'IpAccessAbnormalityAlertStream customise Email body')
-from IpAccessAbnormalityAlertStream#window.length(1) AS A join ApimAlertStakeholderInfoInMemory as S
+from IpAccessAbnormalityAlertStream#window.length(1) AS A join ApimAlertStakeholderInfo as S
 	on ((A.applicationOwner == S.userId and true == S.isSubscriber ) or true == S.isAdmin ) and str:contains(S.alertTypes, 'UnusualIPAccess')
 select 'UnusualIPAccess' as type , str:concat("A request from a ", ifThenElse(str:contains(message, 'old'), 'old', 'new'), " IP (", ip, ") detected by user:" , A.username, " using application:", applicationName, " owned by ", applicationOwner, ".") as message, time:dateFormat(A.alertTimestamp, 'yyyy-MM-dd HH:mm:ss') as alertTimestamp, S.emails
 insert into EmailAlertStream;
@@ -112,22 +99,3 @@ from EmailAlertStream
 select *
 insert into EmailNotificationStream;
 
--- Update the AlertCreatorConfig Table @ start
-@info(name = 'Load ApimAlertStakeholderInfoInMemory at deployment')
-from LoadInMemoryTable join ApimAlertStakeholderInfo
-select userId, alertTypes, emails, isSubscriber, isPublisher, isAdmin
-update or
-insert into ApimAlertStakeholderInfoInMemory
-set ApimAlertStakeholderInfoInMemory.alertTypes = alertTypes, ApimAlertStakeholderInfoInMemory.emails = emails
-	on ApimAlertStakeholderInfoInMemory.userId == userId and ApimAlertStakeholderInfoInMemory.isPublisher == isPublisher and
- ApimAlertStakeholderInfoInMemory.isSubscriber == isSubscriber and ApimAlertStakeholderInfoInMemory.isAdmin == isAdmin;
-
--- Data updating logic
-@info(name = 'Runtime update of configuration table')
-from AlertStakeholderInfoStream
-select userId, alertTypes, emails, isSubscriber, isPublisher, isAdmin
-update or
-insert into ApimAlertStakeholderInfoInMemory
-set ApimAlertStakeholderInfoInMemory.alertTypes = alertTypes, ApimAlertStakeholderInfoInMemory.emails = emails
-	on ApimAlertStakeholderInfoInMemory.userId == userId and ApimAlertStakeholderInfoInMemory.isPublisher == isPublisher and
- ApimAlertStakeholderInfoInMemory.isSubscriber == isSubscriber and ApimAlertStakeholderInfoInMemory.isAdmin == isAdmin;

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/email-notification-siddhi-file/APIM_ALERT_EMAIL_NOTIFICATION.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/email-notification-siddhi-file/APIM_ALERT_EMAIL_NOTIFICATION.siddhi
@@ -47,7 +47,6 @@ define stream EmailNotificationStream (
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
 @PrimaryKey('userId', 'isSubscriber', 'isPublisher', 'isAdmin')
-@index('userId', 'isPublisher', 'isAdmin' , 'alertTypes') 
 define table ApimAlertStakeholderInfo(userId string, alertTypes string, emails string, isSubscriber bool, isPublisher bool, isAdmin bool);
 
 @info(name = 'AbnormalBackendTimeAlert customise Email body')

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/APIM_ALERT_CONFIGURATION.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/APIM_ALERT_CONFIGURATION.siddhi
@@ -15,46 +15,15 @@
 */
 
 @App:name("APIM_ALERT_CONFIGURATION")
-@App:description("Store the alert configurations of each API into two different tables from the two streams published corresponding to alert configurations done by the API creator and the subscriber.")
+@App:description("Store the alert configurations of each API into two different tables through Store API from APIM.")
 
--- Stream and table definition for the alerts configured by the API creator
-@source(type = 'inMemory', topic='ApiCreatorAlertConfigurationStream' )
-define stream ApiCreatorAlertConfigurationStream (
-    apiName string,
-    apiVersion string,
-    apiCreator string,
-    apiCreatorTenantDomain string,
-    thresholdResponseTime long,
-    thresholdBackendTime long);
-
-@PrimaryKey('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain')
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
+@PrimaryKey('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain')
+@Index('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain', 'thresholdResponseTime')
+@Index('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain', 'thresholdBackendTime')
 define table ApiCreatorAlertConfiguration (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdResponseTime long, thresholdBackendTime long);
 
--- Stream and table definition for the alerts configured by the API subscriber
-@source(type='inMemory' , topic='ApiSubscriberAlertConfigurationStream')
-define stream ApiSubscriberAlertConfigurationStream (
-    applicationId string,
-    subscriber string,
-    apiName string,
-    apiVersion string,
-    thresholdRequestCountPerMin int);
-
-@PrimaryKey('applicationId','apiName', 'apiVersion')
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
+@PrimaryKey('applicationId','apiName', 'apiVersion')
+@index('applicationId', 'apiName', 'apiVersion', 'thresholdRequestCountPerMin')
 define table ApiSubAlertConf (applicationId string, subscriber string, apiName string, apiVersion string, thresholdRequestCountPerMin int);
-
--- Data storing logic
-@info(name='Update or Insert ApiCreatorAlertConfiguration')
-from ApiCreatorAlertConfigurationStream
-select *
-update or insert into ApiCreatorAlertConfiguration
-set ApiCreatorAlertConfiguration.thresholdResponseTime = thresholdResponseTime, ApiCreatorAlertConfiguration.thresholdBackendTime = thresholdBackendTime
-on ApiCreatorAlertConfiguration.apiName == apiName and ApiCreatorAlertConfiguration.apiVersion == apiVersion and ApiCreatorAlertConfiguration.apiCreator == apiCreator and ApiCreatorAlertConfiguration.apiCreatorTenantDomain == apiCreatorTenantDomain;
-
-@info(name='Update or Insert ApiSubscriberAlertConfigurationStream')
-from ApiSubscriberAlertConfigurationStream
-select *
-update or insert into ApiSubAlertConf
-set ApiSubAlertConf.thresholdRequestCountPerMin = thresholdRequestCountPerMin
-on ApiSubAlertConf.applicationId == applicationId and ApiSubAlertConf.apiName == apiName and ApiSubAlertConf.apiVersion == apiVersion;

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/APIM_ALERT_CONFIGURATION.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/APIM_ALERT_CONFIGURATION.siddhi
@@ -19,11 +19,9 @@
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
 @PrimaryKey('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain')
-@Index('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain', 'thresholdResponseTime')
-@Index('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain', 'thresholdBackendTime')
 define table ApiCreatorAlertConfiguration (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdResponseTime long, thresholdBackendTime long);
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
 @PrimaryKey('applicationId','apiName', 'apiVersion')
-@index('applicationId', 'apiName', 'apiVersion', 'thresholdRequestCountPerMin')
+@Index('applicationId', 'apiName', 'apiVersion', 'thresholdRequestCountPerMin')
 define table ApiSubAlertConf (applicationId string, subscriber string, apiName string, apiVersion string, thresholdRequestCountPerMin int);

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/APIM_ALERT_STAKEHOLDER.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/APIM_ALERT_STAKEHOLDER.siddhi
@@ -15,25 +15,9 @@
 */
 
 @App:name('APIM_ALERT_STAKEHOLDER')
-@App:description('Store the alert subscribers information in the database')
+@App:description('Store the alert subscribers information in the database through Stroe API from APIM')
 
-@source(type='inMemory' , topic='AlertStakeholderInfoStream')
-define stream AlertStakeholderInfoStream (
-    userId string,
-    alertTypes string,
-    emails string,
-    isSubscriber bool,
-    isPublisher bool,
-    isAdmin bool);
-
-@PrimaryKey('userId','isSubscriber','isPublisher','isAdmin')
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
+@PrimaryKey('userId','isSubscriber','isPublisher','isAdmin')
+@index('userId', 'isPublisher', 'isAdmin' , 'alertTypes')
 define table ApimAlertStakeholderInfo(userId string, alertTypes	string, emails	string, isSubscriber bool, isPublisher	bool, isAdmin	bool);
-
-@info(name='Insert or Update AlertStakeholderInfo Table')
-from AlertStakeholderInfoStream
-select userId, alertTypes, emails, isSubscriber, isPublisher, isAdmin
-update or insert into ApimAlertStakeholderInfo
-set ApimAlertStakeholderInfo.alertTypes = alertTypes, ApimAlertStakeholderInfo.emails = emails
-on ApimAlertStakeholderInfo.userId == userId and ApimAlertStakeholderInfo.isPublisher == isSubscriber and
-    ApimAlertStakeholderInfo.isPublisher == isPublisher and ApimAlertStakeholderInfo.isAdmin == isAdmin;

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/APIM_ALERT_STAKEHOLDER.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/APIM_ALERT_STAKEHOLDER.siddhi
@@ -19,5 +19,4 @@
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
 @PrimaryKey('userId','isSubscriber','isPublisher','isAdmin')
-@index('userId', 'isPublisher', 'isAdmin' , 'alertTypes')
 define table ApimAlertStakeholderInfo(userId string, alertTypes	string, emails	string, isSubscriber bool, isPublisher	bool, isAdmin	bool);

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/APIM_EVENT_RECEIVER.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/APIM_EVENT_RECEIVER.siddhi
@@ -29,37 +29,6 @@ define stream workflowStream(
     updatedTime long
 );
 
--- Stream definition for the alerts configured by the API creator
-@source(type = 'wso2event', wso2.stream.id = 'org.wso2.apimgt.creator.alert.configuration:1.0.0', @map(type = 'wso2event'))
-@sink(type='inMemory' , topic='ApiCreatorAlertConfigurationStream')
-define stream ApiCreatorAlertConfigurationStream (
-    apiName string,
-    apiVersion string,
-    apiCreator string,
-    apiCreatorTenantDomain string,
-    thresholdResponseTime long,
-    thresholdBackendTime long);
-
--- Stream definition for the alerts configured by the API subscriber
-@source(type = 'wso2event', wso2.stream.id = 'org.wso2.apimgt.subscriber.alert.configuration:1.0.0', @map(type = 'wso2event'))
-@sink(type='inMemory' , topic='ApiSubscriberAlertConfigurationStream')
-define stream ApiSubscriberAlertConfigurationStream (
-    applicationId string,
-    subscriber string,
-    apiName string,
-    apiVersion string,
-    thresholdRequestCountPerMin int);
-
-@source(type = 'wso2event', wso2.stream.id = 'org.wso2.analytics.apim.alertStakeholderInfo:1.0.1', @map(type = 'wso2event'))
-@sink(type='inMemory' , topic='AlertStakeholderInfoStream')
-define stream AlertStakeholderInfoStream (
-    userId string,
-    alertTypes string,
-    emails string,
-    isSubscriber bool,
-    isPublisher bool,
-    isAdmin bool);
-
 @source(type = 'mgwfile', wso2.stream.id = 'org.wso2.apimgt.statistics.request:3.0.0', @map(type = 'wso2event'))
 @source(type = 'wso2event', wso2.stream.id = 'org.wso2.apimgt.statistics.request:3.0.0', @map(type = 'wso2event'))
 define stream InComingRequestStream (meta_clientType string,

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_abnormal_backend_time_0.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_abnormal_backend_time_0.siddhi
@@ -17,6 +17,9 @@
 @App:name("apim_alert_abnormal_backend_time_0")
 @App:description("Identifies the API requests with abnormal backend time and add to AllAlertStream and AbnormalBackendTimeAlertStream")
 
+define trigger LoadInMemoryTable at 'start';
+define trigger PeriodicTrigger at every 5 minutes;
+
 @source(type = 'inMemory' , topic = 'APIM_REQUEST')
 define stream Request (meta_clientType string, applicationConsumerKey string, applicationName string, applicationId string, applicationOwner string, apiContext string, apiName string, apiVersion string, apiResourcePath string, apiResourceTemplate string, apiMethod string, apiCreator string, apiCreatorTenantDomain string, apiTier string, apiHostname string, username string, userTenantDomain string, userIp string, userAgent string, requestTimestamp long, throttledOut bool, responseTime long, serviceTime long, backendTime long, responseCacheHit bool, responseSize long, protocol string, responseCode int, destination string, securityLatency long, throttlingLatency long, requestMedLat long, responseMedLat long, backendLatency long, otherLatency long, gatewayType string, label string);
 
@@ -27,19 +30,25 @@ define stream AbnormalBackendTimeAlertStream( apiName string, apiVersion string,
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
 @PrimaryKey('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain')
-@Index('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain', 'thresholdResponseTime')
-@Index('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain', 'thresholdBackendTime')
 define table ApiCreatorAlertConfiguration (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdResponseTime long, thresholdBackendTime long);
+
+@PrimaryKey('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain')
+define table ApiCreatorAlertConfigurationInMemoryTable (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdBackendTime long);
 
 -- Join the request stream with in memory configuration tables to get threashold values.
 @info(name = 'creatorConfigurationInfoRetrieveQuery')
-from Request as R join ApiCreatorAlertConfiguration as C
- 	on (R.apiName == C.apiName and R.apiVersion == C.apiVersion and R.apiCreator == C.apiCreator and R.apiCreatorTenantDomain == C.apiCreatorTenantDomain and C.thresholdBackendTime > 0 and R.backendTime > C.thresholdBackendTime)
+from Request as R join ApiCreatorAlertConfigurationInMemoryTable as C
+ 	on (R.apiName == C.apiName and R.apiVersion == C.apiVersion and R.apiCreator == C.apiCreator and R.apiCreatorTenantDomain == C.apiCreatorTenantDomain)
 select R.apiName, R.apiVersion, R.apiCreator, R.apiCreatorTenantDomain, R.apiResourceTemplate, R.apiMethod, R.backendTime, C.thresholdBackendTime
 insert into AbnormalBackendTimeAlertStreamTemp;
 
+@info(name = 'FilterForAlerting')
+from AbnormalBackendTimeAlertStreamTemp[ thresholdBackendTime > 0 and backendTime > thresholdBackendTime ]
+select *
+insert into AbnormalBackendTimeAlertStreamTemp2;
+
 @info(name = 'Alert Suppression')
-from AbnormalBackendTimeAlertStreamTemp#window.length(1) as a left outer join SuppressedAbnormalBackendTimeAlertStream#window.time(10 minute) as b
+from AbnormalBackendTimeAlertStreamTemp2#window.length(1) as a left outer join SuppressedAbnormalBackendTimeAlertStream#window.time(10 minute) as b
  	on (a.apiName == b.apiName and a.apiVersion == b.apiVersion and a.apiCreator == b.apiCreator and a.apiCreatorTenantDomain == b.apiCreatorTenantDomain and a.apiResourceTemplate == b.apiResourceTemplate and a.apiMethod == b.apiMethod)
 select a.apiName, a.apiVersion, a.apiCreator, a.apiCreatorTenantDomain, a.apiResourceTemplate, a.apiMethod, a.backendTime, a.thresholdBackendTime
  	having b.apiName is null
@@ -49,3 +58,22 @@ insert into SuppressedAbnormalBackendTimeAlertStream;
 from SuppressedAbnormalBackendTimeAlertStream
 select apiName, apiVersion, ifThenElse(apiCreatorTenantDomain == 'carbon.super', str:concat(apiCreator, "@carbon.super"), apiCreator) as apiCreator, apiCreatorTenantDomain, apiResourceTemplate, apiMethod, backendTime, thresholdBackendTime, 'Abnormal backend time detected.' as message, 3 as severity, (time:timestampInMilliseconds()) as alertTimestamp
 insert into AbnormalBackendTimeAlertStream;
+
+@info(name='Update IntermediateStream') 
+from LoadInMemoryTable 
+select triggered_time 
+insert into InMemoryTableJoinStream;
+
+@info(name='Update IntermediateStream periodically') 
+from PeriodicTrigger  
+select triggered_time 
+insert into InMemoryTableJoinStream;
+
+-- Update the AlertCreatorConfig Table @ start
+@info(name = 'Load ApiCreatorAlertConfigurationInMemoryTable')
+from InMemoryTableJoinStream join ApiCreatorAlertConfiguration
+select apiName, apiVersion, apiCreator, apiCreatorTenantDomain, thresholdBackendTime
+update or
+insert into ApiCreatorAlertConfigurationInMemoryTable
+set ApiCreatorAlertConfiguration.thresholdBackendTime = thresholdBackendTime
+ 	on ApiCreatorAlertConfigurationInMemoryTable.apiName == apiName and ApiCreatorAlertConfigurationInMemoryTable.apiVersion == apiVersion and ApiCreatorAlertConfigurationInMemoryTable.apiCreator == apiCreator and ApiCreatorAlertConfigurationInMemoryTable.apiCreatorTenantDomain == apiCreatorTenantDomain;

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_abnormal_backend_time_0.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_abnormal_backend_time_0.siddhi
@@ -17,19 +17,8 @@
 @App:name("apim_alert_abnormal_backend_time_0")
 @App:description("Identifies the API requests with abnormal backend time and add to AllAlertStream and AbnormalBackendTimeAlertStream")
 
-define trigger LoadInMemoryTable at 'start';
-
 @source(type = 'inMemory' , topic = 'APIM_REQUEST')
 define stream Request (meta_clientType string, applicationConsumerKey string, applicationName string, applicationId string, applicationOwner string, apiContext string, apiName string, apiVersion string, apiResourcePath string, apiResourceTemplate string, apiMethod string, apiCreator string, apiCreatorTenantDomain string, apiTier string, apiHostname string, username string, userTenantDomain string, userIp string, userAgent string, requestTimestamp long, throttledOut bool, responseTime long, serviceTime long, backendTime long, responseCacheHit bool, responseSize long, protocol string, responseCode int, destination string, securityLatency long, throttlingLatency long, requestMedLat long, responseMedLat long, backendLatency long, otherLatency long, gatewayType string, label string);
-
-@source(type = 'inMemory', topic = 'ApiCreatorAlertConfigurationStream' )
-define stream ApiCreatorAlertConfigurationStream (
- apiName string,
- apiVersion string,
- apiCreator string,
- apiCreatorTenantDomain string,
- thresholdResponseTime long,
- thresholdBackendTime long);
 
 define stream SuppressedAbnormalBackendTimeAlertStream(apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, apiResourceTemplate string, apiMethod string, backendTime long, thresholdBackendTime long);
 
@@ -38,25 +27,19 @@ define stream AbnormalBackendTimeAlertStream( apiName string, apiVersion string,
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
 @PrimaryKey('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain')
+@Index('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain', 'thresholdResponseTime')
+@Index('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain', 'thresholdBackendTime')
 define table ApiCreatorAlertConfiguration (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdResponseTime long, thresholdBackendTime long);
-
-@PrimaryKey('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain')
-define table ApiCreatorAlertConfigurationInMemoryTable (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdBackendTime long);
 
 -- Join the request stream with in memory configuration tables to get threashold values.
 @info(name = 'creatorConfigurationInfoRetrieveQuery')
-from Request as R join ApiCreatorAlertConfigurationInMemoryTable as C
- 	on (R.apiName == C.apiName and R.apiVersion == C.apiVersion and R.apiCreator == C.apiCreator and R.apiCreatorTenantDomain == C.apiCreatorTenantDomain)
+from Request as R join ApiCreatorAlertConfiguration as C
+ 	on (R.apiName == C.apiName and R.apiVersion == C.apiVersion and R.apiCreator == C.apiCreator and R.apiCreatorTenantDomain == C.apiCreatorTenantDomain and C.thresholdBackendTime > 0 and R.backendTime > C.thresholdBackendTime)
 select R.apiName, R.apiVersion, R.apiCreator, R.apiCreatorTenantDomain, R.apiResourceTemplate, R.apiMethod, R.backendTime, C.thresholdBackendTime
 insert into AbnormalBackendTimeAlertStreamTemp;
 
-@info(name = 'FilterForAlerting')
-from AbnormalBackendTimeAlertStreamTemp[ backendTime > thresholdBackendTime ]
-select *
-insert into AbnormalBackendTimeAlertStreamTemp2;
-
 @info(name = 'Alert Suppression')
-from AbnormalBackendTimeAlertStreamTemp2#window.length(1) as a left outer join SuppressedAbnormalBackendTimeAlertStream#window.time(10 minute) as b
+from AbnormalBackendTimeAlertStreamTemp#window.length(1) as a left outer join SuppressedAbnormalBackendTimeAlertStream#window.time(10 minute) as b
  	on (a.apiName == b.apiName and a.apiVersion == b.apiVersion and a.apiCreator == b.apiCreator and a.apiCreatorTenantDomain == b.apiCreatorTenantDomain and a.apiResourceTemplate == b.apiResourceTemplate and a.apiMethod == b.apiMethod)
 select a.apiName, a.apiVersion, a.apiCreator, a.apiCreatorTenantDomain, a.apiResourceTemplate, a.apiMethod, a.backendTime, a.thresholdBackendTime
  	having b.apiName is null
@@ -66,28 +49,3 @@ insert into SuppressedAbnormalBackendTimeAlertStream;
 from SuppressedAbnormalBackendTimeAlertStream
 select apiName, apiVersion, ifThenElse(apiCreatorTenantDomain == 'carbon.super', str:concat(apiCreator, "@carbon.super"), apiCreator) as apiCreator, apiCreatorTenantDomain, apiResourceTemplate, apiMethod, backendTime, thresholdBackendTime, 'Abnormal backend time detected.' as message, 3 as severity, (time:timestampInMilliseconds()) as alertTimestamp
 insert into AbnormalBackendTimeAlertStream;
-
--- Update the AlertCreatorConfig Table @ start
-@info(name = 'Load ApiCreatorAlertConfigurationInMemoryTable')
-from LoadInMemoryTable join ApiCreatorAlertConfiguration
- 	on thresholdBackendTime > 0
-select apiName, apiVersion, apiCreator, apiCreatorTenantDomain, thresholdBackendTime
-update or
-insert into ApiCreatorAlertConfigurationInMemoryTable
-set ApiCreatorAlertConfiguration.thresholdBackendTime = thresholdBackendTime
- 	on ApiCreatorAlertConfigurationInMemoryTable.apiName == apiName and ApiCreatorAlertConfigurationInMemoryTable.apiVersion == apiVersion and ApiCreatorAlertConfigurationInMemoryTable.apiCreator == apiCreator and ApiCreatorAlertConfigurationInMemoryTable.apiCreatorTenantDomain == apiCreatorTenantDomain;
-
--- Update AlertCreatorConfig table if receive event form APIM
-@info(name = 'Update ApiCreatorAlertConfigurationInMemoryTable')
-from ApiCreatorAlertConfigurationStream[thresholdBackendTime > 0]
-select apiName, apiVersion, apiCreator, apiCreatorTenantDomain, thresholdBackendTime
-update or
-insert into ApiCreatorAlertConfigurationInMemoryTable
-set ApiCreatorAlertConfiguration.thresholdBackendTime = thresholdBackendTime
- 	on ApiCreatorAlertConfigurationInMemoryTable.apiName == apiName and ApiCreatorAlertConfigurationInMemoryTable.apiVersion == apiVersion and ApiCreatorAlertConfigurationInMemoryTable.apiCreator == apiCreator and ApiCreatorAlertConfigurationInMemoryTable.apiCreatorTenantDomain == apiCreatorTenantDomain;
-
-@info(name='DeleteConfigurationif updated value is zero')
-from ApiCreatorAlertConfigurationStream[thresholdResponseTime == 0]
-select apiName, apiVersion, apiCreator, apiCreatorTenantDomain, thresholdResponseTime
-delete  ApiCreatorAlertConfigurationInMemoryTable
- 	on ApiCreatorAlertConfigurationInMemoryTable.apiName == apiName and ApiCreatorAlertConfigurationInMemoryTable.apiVersion == apiVersion and ApiCreatorAlertConfigurationInMemoryTable.apiCreator == apiCreator and ApiCreatorAlertConfigurationInMemoryTable.apiCreatorTenantDomain == apiCreatorTenantDomain;

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_abnormal_request_count_0.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_abnormal_request_count_0.siddhi
@@ -17,19 +17,10 @@
 @App:name("apim_alert_abnormal_request_count_0")
 @App:description("Identifies the API requests with abnormal request count per minute and add to AllAlertStream and AbnormalRequestCountAlertStream")
 
-define trigger LoadInMemoryTable at 'start';
 define trigger MinTriggerEventStream at every 1 minute;
 
 -- This stream definition is only to define the Aggregation. It does not consume the actual API request.
 define stream Request (meta_clientType string, applicationConsumerKey string, applicationName string, applicationId string, applicationOwner string, apiContext string,apiName string, apiVersion string, apiResourcePath string, apiResourceTemplate string, apiMethod string, apiCreator string, apiCreatorTenantDomain string, apiTier string, apiHostname string, username string, userTenantDomain string, userIp string, userAgent string, requestTimestamp long, throttledOut bool, responseTime long, serviceTime long, backendTime long, responseCacheHit bool, responseSize long, protocol string, responseCode int, destination string, securityLatency long, throttlingLatency long, requestMedLat long, responseMedLat long, backendLatency long, otherLatency long, gatewayType string, label string);
-
-@source(type = 'inMemory' , topic = 'ApiSubscriberAlertConfigurationStream')
-define stream ApiSubscriberAlertConfigurationStream (
- applicationId string,
- subscriber string,
- apiName string,
- apiVersion string,
- thresholdRequestCountPerMin int);
 
 define stream SuppressedAbnormalRequestsCountStream(applicationName string, applicationOwner string, tenantDomain string, apiName string, apiVersion string, requestCountPerMin long, thresholdRequestCountPerMin int);
 
@@ -38,10 +29,8 @@ define stream AbnormalRequestsCountAlertStream(applicationName string, applicati
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
 @PrimaryKey('applicationId', 'apiName', 'apiVersion')
+@Index('applicationId', 'apiName', 'apiVersion', 'thresholdRequestCountPerMin')
 define table ApiSubAlertConf (applicationId string, subscriber string, apiName string, apiVersion string, thresholdRequestCountPerMin int);
-
-@PrimaryKey('applicationId', 'apiName', 'apiVersion')
-define table ApiSubAlertConfInMemory (applicationId string, apiName string, apiVersion string, thresholdRequestCountPerMin int);
 
 -- This aggregation definition is only for retrieving data. No data is actually aggregated from this.
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
@@ -72,18 +61,13 @@ select apiName, apiVersion, applicationId, applicationName, applicationOwner, us
 insert current events into RequestsPerMinStream;
 
 @info(name = 'configurationInfoRetrieveQuery')
-from RequestsPerMinStream as R join ApiSubAlertConfInMemory as T
-	on ( R.applicationId == T.applicationId and R.apiName == T.apiName and R.apiVersion == T.apiVersion)
+from RequestsPerMinStream as R join ApiSubAlertConf as T
+	on ( R.applicationId == T.applicationId and R.apiName == T.apiName and R.apiVersion == T.apiVersion and T.thresholdRequestCountPerMin > 0 and R.requestCountPerMin > T.thresholdRequestCountPerMin )
 select R.applicationName, R.applicationOwner, R.tenantDomain, R.apiName, R.apiVersion, R.requestCountPerMin, T.thresholdRequestCountPerMin
 insert into AbnormalRequestsPerMinAlertStreamTemp;
 
-@info(name = 'FilterForAlerting')
-from AbnormalRequestsPerMinAlertStreamTemp[ requestCountPerMin > thresholdRequestCountPerMin ]
-select *
-insert into AbnormalRequestsPerMinAlertStreamTemp2;
-
 @info(name = 'Alert Suppression')
-from AbnormalRequestsPerMinAlertStreamTemp2#window.length(1) as a left outer join SuppressedAbnormalRequestsCountStream#window.time(10 minute) as b
+from AbnormalRequestsPerMinAlertStreamTemp#window.length(1) as a left outer join SuppressedAbnormalRequestsCountStream#window.time(10 minute) as b
 	on (a.applicationName == b.applicationName and a.applicationOwner == b.applicationOwner and a.tenantDomain == b.tenantDomain and
  a.apiName == b.apiName and a.apiVersion == b.apiVersion)
 select a.applicationName, a.applicationOwner, a.tenantDomain, a.apiName, a.apiVersion, a.requestCountPerMin, a.thresholdRequestCountPerMin
@@ -95,27 +79,3 @@ from SuppressedAbnormalRequestsCountStream
 select applicationName, applicationOwner, tenantDomain, apiName, apiVersion, requestCountPerMin, thresholdRequestCountPerMin, 'Abnormal request count detected during last minute.' as message , 2 as severity, (time:timestampInMilliseconds()) as alertTimestamp
 insert into AbnormalRequestsCountAlertStream;
 
--- Update the ApiSubAlertConf Table @ start
-@info(name = 'Load ApiSubAlertConfInMemory')
-from LoadInMemoryTable join ApiSubAlertConf
- 	on thresholdRequestCountPerMin > 0
-select applicationId, apiName, apiVersion, thresholdRequestCountPerMin
-update or
-insert into ApiSubAlertConfInMemory
-set ApiSubAlertConfInMemory.thresholdRequestCountPerMin = thresholdRequestCountPerMin
-	on ApiSubAlertConfInMemory.applicationId == applicationId and ApiSubAlertConfInMemory.apiName == apiName and ApiSubAlertConfInMemory.apiVersion == apiVersion;
-
--- Update ApiSubAlertConf table if receive event form APIM
-@info(name = 'Update ApiSubAlertConfInMemory')
-from ApiSubscriberAlertConfigurationStream[thresholdRequestCountPerMin > 0]
-select applicationId, apiName, apiVersion, thresholdRequestCountPerMin
-update or
-insert into ApiSubAlertConfInMemory
-set ApiSubAlertConfInMemory.thresholdRequestCountPerMin = thresholdRequestCountPerMin
-	on ApiSubAlertConfInMemory.applicationId == applicationId and ApiSubAlertConfInMemory.apiName == apiName and ApiSubAlertConfInMemory.apiVersion == apiVersion;
-
-@info(name = 'Delete ApiSubAlertConfInMemory when config is 0')
-from ApiSubscriberAlertConfigurationStream[thresholdRequestCountPerMin == 0]
-select applicationId, apiName, apiVersion, thresholdRequestCountPerMin
-delete  ApiSubAlertConfInMemory
-	on ApiSubAlertConfInMemory.applicationId == applicationId and ApiSubAlertConfInMemory.apiName == apiName and ApiSubAlertConfInMemory.apiVersion == apiVersion;

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_abnormal_response_time_0.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_abnormal_response_time_0.siddhi
@@ -17,6 +17,9 @@
 @App:name("apim_alert_abnormal_response_time_0")
 @App:description("Identifies the API requests with abnormal response time and add to AllAlertStream and AbnormalResponseTimeAlertStream")
 
+define trigger LoadInMemoryTable at 'start';
+define trigger PeriodicTrigger at every 5 minutes;
+
 @source(type='inMemory' , topic='APIM_REQUEST')
 define stream Request (meta_clientType string, applicationConsumerKey string, applicationName string, applicationId string, applicationOwner string, apiContext string,apiName string, apiVersion string, apiResourcePath string, apiResourceTemplate string, apiMethod string, apiCreator string, apiCreatorTenantDomain string, apiTier string, apiHostname string, username string, userTenantDomain string, userIp string, userAgent string, requestTimestamp long, throttledOut bool, responseTime long, serviceTime long, backendTime long, responseCacheHit bool, responseSize long, protocol string, responseCode int, destination string, securityLatency long, throttlingLatency long, requestMedLat long, responseMedLat long, backendLatency long, otherLatency long, gatewayType string, label string);
 
@@ -27,18 +30,24 @@ define stream AbnormalResponseTimeAlertStream( apiName string, apiVersion string
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
 @PrimaryKey('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain')
-@Index('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain', 'thresholdResponseTime')
-@Index('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain', 'thresholdBackendTime')
 define table ApiCreatorAlertConfiguration (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdResponseTime long, thresholdBackendTime long);
 
+@PrimaryKey('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain')
+define table ApiCreatorAlertConfigurationInMemoryTable (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdResponseTime long);
+
 @info(name = 'creatorConfigurationInfoRetrievQuery')
-from Request as R join ApiCreatorAlertConfiguration as C
-on (R.apiName == C.apiName and R.apiVersion == C.apiVersion and R.apiCreator== C.apiCreator and R.apiCreatorTenantDomain == C.apiCreatorTenantDomain and C.thresholdResponseTime> 0 and R.responseTime > C.thresholdResponseTime)
+from Request as R join ApiCreatorAlertConfigurationInMemoryTable as C
+on (R.apiName == C.apiName and R.apiVersion == C.apiVersion and R.apiCreator== C.apiCreator and R.apiCreatorTenantDomain == C.apiCreatorTenantDomain)
 select R.apiName, R.apiVersion,  R.apiCreator, R.apiCreatorTenantDomain, R.apiResourceTemplate, R.apiMethod, R.responseTime, thresholdResponseTime
 insert into AbnormalResponseTimeAlertStreamTemp;
 
+@info(name='FilterForAlerting')
+from AbnormalResponseTimeAlertStreamTemp[thresholdResponseTime >0 and responseTime > thresholdResponseTime ]
+select *
+insert into AbnormalResponseTimeAlertStreamTemp2;
+
 @info(name = 'Alert Suppression')
-from AbnormalResponseTimeAlertStreamTemp#window.length(1) as a left outer join SuppressedAbnormalResponseTimeAlertStream#window.time(10 minute) as b
+from AbnormalResponseTimeAlertStreamTemp2#window.length(1) as a left outer join SuppressedAbnormalResponseTimeAlertStream#window.time(10 minute) as b
 on (a.apiName == b.apiName and a.apiVersion== b.apiVersion and a.apiCreator== b.apiCreator and a.apiCreatorTenantDomain==b.apiCreatorTenantDomain and
     a.apiResourceTemplate==b.apiResourceTemplate and a.apiMethod== b.apiMethod)
 select a.apiName, a.apiVersion, a.apiCreator, a.apiCreatorTenantDomain, a.apiResourceTemplate, a.apiMethod, a.responseTime, a.thresholdResponseTime
@@ -49,5 +58,24 @@ from SuppressedAbnormalResponseTimeAlertStream
 select apiName, apiVersion,  ifThenElse(apiCreatorTenantDomain == 'carbon.super', str:concat(apiCreator, "@carbon.super"), apiCreator) as apiCreator, apiCreatorTenantDomain, apiResourceTemplate, apiMethod, responseTime, thresholdResponseTime ,
     'Abnormal response time detected.' as message, 2 as severity, (time:timestampInMilliseconds()) as alertTimestamp
 insert into AbnormalResponseTimeAlertStream;
+
+@info(name='Update IntermediateStream') 
+from LoadInMemoryTable 
+select triggered_time 
+insert into InMemoryTableJoinStream;
+
+@info(name='Update IntermediateStream periodically') 
+from PeriodicTrigger  
+select triggered_time 
+insert into InMemoryTableJoinStream;
+
+-- Update the AlertCreatorConfig Table @ start
+@info(name = 'Load ApiCreatorAlertConfigurationInMemoryTable')
+from InMemoryTableJoinStream join ApiCreatorAlertConfiguration
+select apiName, apiVersion, apiCreator, apiCreatorTenantDomain, thresholdResponseTime
+update or
+insert into ApiCreatorAlertConfigurationInMemoryTable
+set ApiCreatorAlertConfiguration.thresholdResponseTime = thresholdResponseTime
+ 	on ApiCreatorAlertConfigurationInMemoryTable.apiName == apiName and ApiCreatorAlertConfigurationInMemoryTable.apiVersion == apiVersion and ApiCreatorAlertConfigurationInMemoryTable.apiCreator == apiCreator and ApiCreatorAlertConfigurationInMemoryTable.apiCreatorTenantDomain == apiCreatorTenantDomain;
 
 

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_abnormal_response_time_0.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_abnormal_response_time_0.siddhi
@@ -17,19 +17,8 @@
 @App:name("apim_alert_abnormal_response_time_0")
 @App:description("Identifies the API requests with abnormal response time and add to AllAlertStream and AbnormalResponseTimeAlertStream")
 
-define trigger LoadInMemoryTable at 'start';
-
 @source(type='inMemory' , topic='APIM_REQUEST')
 define stream Request (meta_clientType string, applicationConsumerKey string, applicationName string, applicationId string, applicationOwner string, apiContext string,apiName string, apiVersion string, apiResourcePath string, apiResourceTemplate string, apiMethod string, apiCreator string, apiCreatorTenantDomain string, apiTier string, apiHostname string, username string, userTenantDomain string, userIp string, userAgent string, requestTimestamp long, throttledOut bool, responseTime long, serviceTime long, backendTime long, responseCacheHit bool, responseSize long, protocol string, responseCode int, destination string, securityLatency long, throttlingLatency long, requestMedLat long, responseMedLat long, backendLatency long, otherLatency long, gatewayType string, label string);
-
-@source(type = 'inMemory', topic='ApiCreatorAlertConfigurationStream' )
-define stream ApiCreatorAlertConfigurationStream (
-    apiName string,
-    apiVersion string,
-    apiCreator string,
-    apiCreatorTenantDomain string,
-    thresholdResponseTime long,
-    thresholdBackendTime long);
 
 define stream SuppressedAbnormalResponseTimeAlertStream(apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, apiResourceTemplate string, apiMethod string, responseTime long, thresholdResponseTime long);
 
@@ -38,24 +27,18 @@ define stream AbnormalResponseTimeAlertStream( apiName string, apiVersion string
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
 @PrimaryKey('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain')
+@Index('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain', 'thresholdResponseTime')
+@Index('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain', 'thresholdBackendTime')
 define table ApiCreatorAlertConfiguration (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdResponseTime long, thresholdBackendTime long);
 
-@PrimaryKey('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain')
-define table ApiCreatorAlertConfigurationInMemoryTable (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdResponseTime long);
-
 @info(name = 'creatorConfigurationInfoRetrievQuery')
-from Request as R join ApiCreatorAlertConfigurationInMemoryTable as C
-on (R.apiName == C.apiName and R.apiVersion == C.apiVersion and R.apiCreator== C.apiCreator and R.apiCreatorTenantDomain == C.apiCreatorTenantDomain)
+from Request as R join ApiCreatorAlertConfiguration as C
+on (R.apiName == C.apiName and R.apiVersion == C.apiVersion and R.apiCreator== C.apiCreator and R.apiCreatorTenantDomain == C.apiCreatorTenantDomain and C.thresholdResponseTime> 0 and R.responseTime > C.thresholdResponseTime)
 select R.apiName, R.apiVersion,  R.apiCreator, R.apiCreatorTenantDomain, R.apiResourceTemplate, R.apiMethod, R.responseTime, thresholdResponseTime
 insert into AbnormalResponseTimeAlertStreamTemp;
 
-@info(name='FilterForAlerting')
-from AbnormalResponseTimeAlertStreamTemp[responseTime > thresholdResponseTime ]
-select *
-insert into AbnormalResponseTimeAlertStreamTemp2;
-
 @info(name = 'Alert Suppression')
-from AbnormalResponseTimeAlertStreamTemp2#window.length(1) as a left outer join SuppressedAbnormalResponseTimeAlertStream#window.time(10 minute) as b
+from AbnormalResponseTimeAlertStreamTemp#window.length(1) as a left outer join SuppressedAbnormalResponseTimeAlertStream#window.time(10 minute) as b
 on (a.apiName == b.apiName and a.apiVersion== b.apiVersion and a.apiCreator== b.apiCreator and a.apiCreatorTenantDomain==b.apiCreatorTenantDomain and
     a.apiResourceTemplate==b.apiResourceTemplate and a.apiMethod== b.apiMethod)
 select a.apiName, a.apiVersion, a.apiCreator, a.apiCreatorTenantDomain, a.apiResourceTemplate, a.apiMethod, a.responseTime, a.thresholdResponseTime
@@ -67,26 +50,4 @@ select apiName, apiVersion,  ifThenElse(apiCreatorTenantDomain == 'carbon.super'
     'Abnormal response time detected.' as message, 2 as severity, (time:timestampInMilliseconds()) as alertTimestamp
 insert into AbnormalResponseTimeAlertStream;
 
--- Update the AlertCreatorConfig Table @ start
-@info(name='Load ApiCreatorAlertConfigurationInMemoryTable')
-from LoadInMemoryTable join ApiCreatorAlertConfiguration
-on ApiCreatorAlertConfiguration.thresholdResponseTime > 0
-select apiName, apiVersion, apiCreator, apiCreatorTenantDomain, thresholdResponseTime
-update or insert into ApiCreatorAlertConfigurationInMemoryTable
-set ApiCreatorAlertConfiguration.thresholdResponseTime = thresholdResponseTime
-on ApiCreatorAlertConfigurationInMemoryTable.apiName == apiName and ApiCreatorAlertConfigurationInMemoryTable.apiVersion == apiVersion and ApiCreatorAlertConfigurationInMemoryTable.apiCreator == apiCreator and ApiCreatorAlertConfigurationInMemoryTable.apiCreatorTenantDomain == apiCreatorTenantDomain;
-
--- Update AlertCreatorConfig table if receive event form APIM@info(name='Update ApiCreatorAlertConfigurationInMemoryTable')
-@info(name='Update ApiCreatorAlertConfigurationInMemoryTable')
-from ApiCreatorAlertConfigurationStream[thresholdResponseTime > 0]
-select apiName, apiVersion, apiCreator, apiCreatorTenantDomain, thresholdResponseTime
-update or insert into ApiCreatorAlertConfigurationInMemoryTable
-set ApiCreatorAlertConfiguration.thresholdResponseTime = thresholdResponseTime
-on ApiCreatorAlertConfigurationInMemoryTable.apiName == apiName and ApiCreatorAlertConfigurationInMemoryTable.apiVersion == apiVersion and ApiCreatorAlertConfigurationInMemoryTable.apiCreator == apiCreator and ApiCreatorAlertConfigurationInMemoryTable.apiCreatorTenantDomain == apiCreatorTenantDomain;
-
-@info(name='DeleteConfigurationif updated value is zero')
-from ApiCreatorAlertConfigurationStream[thresholdResponseTime == 0]
-select apiName, apiVersion, apiCreator, apiCreatorTenantDomain, thresholdResponseTime
-delete  ApiCreatorAlertConfigurationInMemoryTable
- 	on ApiCreatorAlertConfigurationInMemoryTable.apiName == apiName and ApiCreatorAlertConfigurationInMemoryTable.apiVersion == apiVersion and ApiCreatorAlertConfigurationInMemoryTable.apiCreator == apiCreator and ApiCreatorAlertConfigurationInMemoryTable.apiCreatorTenantDomain == apiCreatorTenantDomain;
 

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_health_availability_0.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_health_availability_0.siddhi
@@ -17,19 +17,8 @@
 @App:name("apim_alert_health_availability_0")
 @App:description("Determines the availablity and health of an api")
 
-define trigger LoadInMemoryTable at 'start';
-
 @source(type = 'inMemory' , topic = 'APIM_REQUEST')
 define stream Request (meta_clientType string, applicationConsumerKey string, applicationName string, applicationId string, applicationOwner string, apiContext string, apiName string, apiVersion string, apiResourcePath string, apiResourceTemplate string, apiMethod string, apiCreator string, apiCreatorTenantDomain string, apiTier string, apiHostname string, username string, userTenantDomain string, userIp string, userAgent string, requestTimestamp long, throttledOut bool, responseTime long, serviceTime long, backendTime long, responseCacheHit bool, responseSize long, protocol string, responseCode int, destination string, securityLatency long, throttlingLatency long, requestMedLat long, responseMedLat long, backendLatency long, otherLatency long, gatewayType string, label string);
-
-@source(type = 'inMemory', topic = 'ApiCreatorAlertConfigurationStream' )
-define stream ApiCreatorAlertConfigurationStream (
- apiName string,
- apiVersion string,
- apiCreator string,
- apiCreatorTenantDomain string,
- thresholdResponseTime long,
- thresholdBackendTime long);
 
 define stream SuppressedResponseTimeAlertStream(apiName string, apiVersion string, apiContext string, apiCreator string, apiCreatorTenantDomain string, thresholdResponseTime long);
 
@@ -40,14 +29,13 @@ define stream ApiHealthMonitorAlertStream(apiName string, apiVersion string, api
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
 @PrimaryKey('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain')
+@Index('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain', 'thresholdResponseTime')
+@Index('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain', 'thresholdBackendTime')
 define table ApiCreatorAlertConfiguration (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdResponseTime long, thresholdBackendTime long);
 
-@PrimaryKey('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain')
-define table ApiCreatorAlertConfigurationInMemoryTable (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdResponseTime long);
-
 @info(name = 'creatorConfigurationInfoRetrievQuery')
-from Request as R join ApiCreatorAlertConfigurationInMemoryTable as C
- 	on(R.apiName == C.apiName and R.apiVersion == C.apiVersion and R.apiCreator == C.apiCreator and R.apiCreatorTenantDomain == C.apiCreatorTenantDomain )
+from Request as R join ApiCreatorAlertConfiguration as C
+ 	on(R.apiName == C.apiName and R.apiVersion == C.apiVersion and R.apiCreator == C.apiCreator and R.apiCreatorTenantDomain == C.apiCreatorTenantDomain)
 select R.apiContext, R.apiName, R.apiVersion, R.apiResourceTemplate, R.apiMethod, R.apiCreator, R.apiCreatorTenantDomain, R.requestTimestamp, R.responseTime, R.backendTime, C.thresholdResponseTime, R.responseCode
 insert into RequestAlertInfoStream;
 
@@ -55,7 +43,7 @@ partition with (apiContext of RequestAlertInfoStream)
 begin
  -- checks whether the response time is higher than the threshold response time continously for 5 times
  	@info(name = 'Abnormal response time pattern check')
- 	from every e1 = RequestAlertInfoStream[responseTime > thresholdResponseTime],e2 = RequestAlertInfoStream[responseTime > thresholdResponseTime],e3 = RequestAlertInfoStream[responseTime > thresholdResponseTime], e4 = RequestAlertInfoStream[responseTime > thresholdResponseTime],e5 = RequestAlertInfoStream[responseTime > thresholdResponseTime]
+ 	from every e1 = RequestAlertInfoStream[thresholdResponseTime > 0 and responseTime > thresholdResponseTime], e2 = RequestAlertInfoStream[thresholdResponseTime > 0 and responseTime > thresholdResponseTime], e3 = RequestAlertInfoStream[thresholdResponseTime > 0 and responseTime > thresholdResponseTime], e4 = RequestAlertInfoStream[thresholdResponseTime > 0 and responseTime > thresholdResponseTime], e5 = RequestAlertInfoStream[thresholdResponseTime > 0 and responseTime > thresholdResponseTime]
  	select e1.apiName, e1.apiVersion, e1.apiContext, e1.apiCreator, e1.apiCreatorTenantDomain, e1.thresholdResponseTime
  	insert into ResponseTimeAlertStream;
 
@@ -90,28 +78,3 @@ insert into ApiHealthMonitorAlertStream;
 from SuppressedResponseCodeAlertStream
 select apiName, apiVersion, ifThenElse(apiCreatorTenantDomain == 'carbon.super', str:concat(apiCreator, "@carbon.super"), apiCreator) as apiCreator, apiCreatorTenantDomain, 'Server error occurred continuously for 5 or more times.' as message, 2 as severity, (time:timestampInMilliseconds()) as alertTimestamp
 insert into ApiHealthMonitorAlertStream;
-
--- Update the AlertCreatorConfig Table @ start
-@info(name = 'Load ApiCreatorAlertConfigurationInMemoryTable')
-from LoadInMemoryTable join ApiCreatorAlertConfiguration
-on thresholdResponseTime > 0
-select apiName, apiVersion, apiCreator, apiCreatorTenantDomain, thresholdResponseTime
-update or
-insert into ApiCreatorAlertConfigurationInMemoryTable
-set ApiCreatorAlertConfiguration.thresholdResponseTime = thresholdResponseTime
- 	on ApiCreatorAlertConfigurationInMemoryTable.apiName == apiName and ApiCreatorAlertConfigurationInMemoryTable.apiVersion == apiVersion and ApiCreatorAlertConfigurationInMemoryTable.apiCreator == apiCreator and ApiCreatorAlertConfigurationInMemoryTable.apiCreatorTenantDomain == apiCreatorTenantDomain;
-
--- Update AlertCreatorConfig table if receive event form APIM
-@info(name = 'Update ApiCreatorAlertConfigurationInMemoryTable')
-from ApiCreatorAlertConfigurationStream[thresholdResponseTime > 0]
-select apiName, apiVersion, apiCreator, apiCreatorTenantDomain, thresholdResponseTime
-update or
-insert into ApiCreatorAlertConfigurationInMemoryTable
-set ApiCreatorAlertConfiguration.thresholdResponseTime = thresholdResponseTime
- 	on ApiCreatorAlertConfigurationInMemoryTable.apiName == apiName and ApiCreatorAlertConfigurationInMemoryTable.apiVersion == apiVersion and ApiCreatorAlertConfigurationInMemoryTable.apiCreator == apiCreator and ApiCreatorAlertConfigurationInMemoryTable.apiCreatorTenantDomain == apiCreatorTenantDomain;
-
-@info(name='DeleteConfigurationif updated value is zero')
-from ApiCreatorAlertConfigurationStream[thresholdResponseTime == 0]
-select apiName, apiVersion, apiCreator, apiCreatorTenantDomain, thresholdResponseTime
-delete  ApiCreatorAlertConfigurationInMemoryTable
- 	on ApiCreatorAlertConfigurationInMemoryTable.apiName == apiName and ApiCreatorAlertConfigurationInMemoryTable.apiVersion == apiVersion and ApiCreatorAlertConfigurationInMemoryTable.apiCreator == apiCreator and ApiCreatorAlertConfigurationInMemoryTable.apiCreatorTenantDomain == apiCreatorTenantDomain;

--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_health_availability_0.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/apim_alert_health_availability_0.siddhi
@@ -17,6 +17,9 @@
 @App:name("apim_alert_health_availability_0")
 @App:description("Determines the availablity and health of an api")
 
+define trigger LoadInMemoryTable at 'start';
+define trigger PeriodicTrigger at every 5 minutes;
+
 @source(type = 'inMemory' , topic = 'APIM_REQUEST')
 define stream Request (meta_clientType string, applicationConsumerKey string, applicationName string, applicationId string, applicationOwner string, apiContext string, apiName string, apiVersion string, apiResourcePath string, apiResourceTemplate string, apiMethod string, apiCreator string, apiCreatorTenantDomain string, apiTier string, apiHostname string, username string, userTenantDomain string, userIp string, userAgent string, requestTimestamp long, throttledOut bool, responseTime long, serviceTime long, backendTime long, responseCacheHit bool, responseSize long, protocol string, responseCode int, destination string, securityLatency long, throttlingLatency long, requestMedLat long, responseMedLat long, backendLatency long, otherLatency long, gatewayType string, label string);
 
@@ -29,13 +32,14 @@ define stream ApiHealthMonitorAlertStream(apiName string, apiVersion string, api
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
 @PrimaryKey('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain')
-@Index('apiName', 'apiVersion','apiCreator', 'apiCreatorTenantDomain', 'thresholdResponseTime')
-@Index('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain', 'thresholdBackendTime')
 define table ApiCreatorAlertConfiguration (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdResponseTime long, thresholdBackendTime long);
 
+@PrimaryKey('apiName', 'apiVersion', 'apiCreator', 'apiCreatorTenantDomain')
+define table ApiCreatorAlertConfigurationInMemoryTable (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, thresholdResponseTime long);
+
 @info(name = 'creatorConfigurationInfoRetrievQuery')
-from Request as R join ApiCreatorAlertConfiguration as C
- 	on(R.apiName == C.apiName and R.apiVersion == C.apiVersion and R.apiCreator == C.apiCreator and R.apiCreatorTenantDomain == C.apiCreatorTenantDomain)
+from Request as R join ApiCreatorAlertConfigurationInMemoryTable as C
+ 	on(R.apiName == C.apiName and R.apiVersion == C.apiVersion and R.apiCreator == C.apiCreator and R.apiCreatorTenantDomain == C.apiCreatorTenantDomain )
 select R.apiContext, R.apiName, R.apiVersion, R.apiResourceTemplate, R.apiMethod, R.apiCreator, R.apiCreatorTenantDomain, R.requestTimestamp, R.responseTime, R.backendTime, C.thresholdResponseTime, R.responseCode
 insert into RequestAlertInfoStream;
 
@@ -43,7 +47,7 @@ partition with (apiContext of RequestAlertInfoStream)
 begin
  -- checks whether the response time is higher than the threshold response time continously for 5 times
  	@info(name = 'Abnormal response time pattern check')
- 	from every e1 = RequestAlertInfoStream[thresholdResponseTime > 0 and responseTime > thresholdResponseTime], e2 = RequestAlertInfoStream[thresholdResponseTime > 0 and responseTime > thresholdResponseTime], e3 = RequestAlertInfoStream[thresholdResponseTime > 0 and responseTime > thresholdResponseTime], e4 = RequestAlertInfoStream[thresholdResponseTime > 0 and responseTime > thresholdResponseTime], e5 = RequestAlertInfoStream[thresholdResponseTime > 0 and responseTime > thresholdResponseTime]
+ 	from every e1 = RequestAlertInfoStream[thresholdResponseTime >0 and responseTime > thresholdResponseTime],e2 = RequestAlertInfoStream[thresholdResponseTime >0 and responseTime > thresholdResponseTime],e3 = RequestAlertInfoStream[thresholdResponseTime >0 and responseTime > thresholdResponseTime], e4 = RequestAlertInfoStream[thresholdResponseTime >0 and responseTime > thresholdResponseTime],e5 = RequestAlertInfoStream[thresholdResponseTime >0 and responseTime > thresholdResponseTime]
  	select e1.apiName, e1.apiVersion, e1.apiContext, e1.apiCreator, e1.apiCreatorTenantDomain, e1.thresholdResponseTime
  	insert into ResponseTimeAlertStream;
 
@@ -78,3 +82,23 @@ insert into ApiHealthMonitorAlertStream;
 from SuppressedResponseCodeAlertStream
 select apiName, apiVersion, ifThenElse(apiCreatorTenantDomain == 'carbon.super', str:concat(apiCreator, "@carbon.super"), apiCreator) as apiCreator, apiCreatorTenantDomain, 'Server error occurred continuously for 5 or more times.' as message, 2 as severity, (time:timestampInMilliseconds()) as alertTimestamp
 insert into ApiHealthMonitorAlertStream;
+
+@info(name='Update IntermediateStream') 
+from LoadInMemoryTable 
+select triggered_time 
+insert into InMemoryTableJoinStream;
+
+@info(name='Update IntermediateStream periodically') 
+from PeriodicTrigger  
+select triggered_time 
+insert into InMemoryTableJoinStream;
+
+-- Update the AlertCreatorConfig Table @ start
+@info(name = 'Load ApiCreatorAlertConfigurationInMemoryTable')
+from InMemoryTableJoinStream join ApiCreatorAlertConfiguration
+select apiName, apiVersion, apiCreator, apiCreatorTenantDomain, thresholdResponseTime
+update or
+insert into ApiCreatorAlertConfigurationInMemoryTable
+set ApiCreatorAlertConfiguration.thresholdResponseTime = thresholdResponseTime
+ 	on ApiCreatorAlertConfigurationInMemoryTable.apiName == apiName and ApiCreatorAlertConfigurationInMemoryTable.apiVersion == apiVersion and ApiCreatorAlertConfigurationInMemoryTable.apiCreator == apiCreator and ApiCreatorAlertConfigurationInMemoryTable.apiCreatorTenantDomain == apiCreatorTenantDomain;
+


### PR DESCRIPTION
## Purpose
Fix in-memory config tables being out of sync with physical tables. Since updates for the configurations are done through store queries from APIM, this can lead to in-memory tables out of sync with physical tables until a restart/ app redeployment

## Goals
Periodically sync in-memory configuration tables

## Approach
Use of a trigger every 5 minutes to update or insert in-memory tables from the records selected from physical tables.

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Migrations (if applicable)
Alter ApiSubAlertConf table with additional index consisting of coloumns 'applicationId', 'apiName', 'apiVersion', 'thresholdRequestCountPerMin' 

## Test environment
MySQL 5.7, JDK 1.8.0_171
