### PR TITLE
Remove apiCreator in ApimApiAvailabilityInfo update

### DIFF
--- a/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/APIM_API_AVAILABILITY.siddhi
+++ b/features/apim-analytics-feature/org.wso2.analytics.solutions.apim.analytics.feature/src/main/resources/siddhi-files/APIM_API_AVAILABILITY.siddhi
@@ -47,7 +47,7 @@ insert into ApimApiAvailabilityInfoUpdateStreamTemp;
 @info(name = 'Batch insert to ApimApiAvailabilityInfo')
 from ApimApiAvailabilityInfoUpdateStreamTemp 
 select *
- 	group by apiName, apiVersion, apiCreator, tenantDomain 
+ 	group by apiName, apiVersion, tenantDomain
 output last every 1 minute 
 insert into ApimApiAvailabilityInfoUpdateStream;
 
@@ -56,4 +56,4 @@ from ApimApiAvailabilityInfoUpdateStream
 select apiName, apiVersion, ifThenElse(tenantDomain == 'carbon.super', str:concat(apiCreator, "@carbon.super"), apiCreator) as apiCreator, tenantDomain, status 
 update or insert into ApimApiAvailabilityInfo 
 set ApimApiAvailabilityInfo.status = status 
- 	on ApimApiAvailabilityInfo.apiName == apiName and ApimApiAvailabilityInfo.apiVersion == apiVersion and ApimApiAvailabilityInfo.apiCreator == apiCreator and ApimApiAvailabilityInfo.tenantDomain == tenantDomain;
+ 	on ApimApiAvailabilityInfo.apiName == apiName and ApimApiAvailabilityInfo.apiVersion == apiVersion and ApimApiAvailabilityInfo.tenantDomain == tenantDomain;


### PR DESCRIPTION
## Purpose
$subject as API creator is changed when the API is modified

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes