### PR TITLE
Fix issues in IS-Analytics dashboard

### DIFF
--- a/components/analytics-solutions-common/org.wso2.analytics.solutions.common/widgets/DateTimeRangePicker/src/widget/DateTimePicker.jsx
+++ b/components/analytics-solutions-common/org.wso2.analytics.solutions.common/widgets/DateTimeRangePicker/src/widget/DateTimePicker.jsx
@@ -359,9 +359,7 @@ class DateTimePicker extends Widget {
         if (granularity.length > 0) {
           this.clearRefreshInterval();
           granularity = granularity.toLowerCase();
-          const supportedGranularities = this.getSupportedGranularitiesForFixed(
-            timeRange
-          );
+          const supportedGranularities = this.getSupportedGranularitiesForFixed(timeRange).supportedGranularities;
           if (
             supportedGranularities.indexOf(
               this.capitalizeCaseFirstChar(granularity)
@@ -803,12 +801,8 @@ class DateTimePicker extends Widget {
       );
     }
     const { granularityMode } = this.state;
-    let defaultSelectedGranularity = this.getSupportedGranularitiesForFixed(
-      granularityMode
-    );
-    return defaultSelectedGranularity[
-      defaultSelectedGranularity.length - 2
-    ].toLowerCase();
+    let defaultSelectedGranularity = this.getSupportedGranularitiesForFixed(granularityMode);
+    return defaultSelectedGranularity.defaultGranularity.toLowerCase();
   }
 
   verifySelectedGranularityForCustom = (granularity) => {
@@ -956,37 +950,42 @@ class DateTimePicker extends Widget {
    */
   getSupportedGranularitiesForFixed = (granularityValue) => {
     let supportedGranularities = [];
+    let defaultGranularityIndex = 0;
     switch (granularityValue) {
       case '1 Min':
       case '15 Min':
         supportedGranularities = ['Second', 'Minute'];
+        defaultGranularityIndex = 0;
         break;
       case '1 Hour':
         supportedGranularities = ['Second', 'Minute', 'Hour'];
+        defaultGranularityIndex = 1;
         break;
       case '1 Day':
       case '7 Days':
         supportedGranularities = ['Second', 'Minute', 'Hour', 'Day'];
+        defaultGranularityIndex = 2;
         break;
       case '1 Month':
+        supportedGranularities = ['Second', 'Minute', 'Hour', 'Day'];
+        defaultGranularityIndex = 3;
+        break;
       case '3 Months':
       case '6 Months':
         supportedGranularities = ['Second', 'Minute', 'Hour', 'Day', 'Month'];
+        defaultGranularityIndex = 4;
         break;
       case '1 Year':
-        supportedGranularities = [
-          'Second',
-          'Minute',
-          'Hour',
-          'Day',
-          'Month',
-          'Year'
-        ];
+        supportedGranularities = ['Second', 'Minute', 'Hour', 'Day', 'Month', 'Year'];
+        defaultGranularityIndex = 4;
         break;
       default:
       // do nothing
     }
-    return supportedGranularities;
+    return {
+      supportedGranularities: supportedGranularities,
+      defaultGranularity: supportedGranularities[defaultGranularityIndex]
+    };
   };
 
   getSupportedGranularitiesForCustom = (startTime, endTime) => {

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAverageSessionDuration/src/IsAnalyticsAverageSessionDuration.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAverageSessionDuration/src/IsAnalyticsAverageSessionDuration.jsx
@@ -124,10 +124,12 @@ class IsAnalyticsAverageSessionDuration extends Widget {
         super.getWidgetChannelManager().unsubscribeWidget(this.props.id);
         const dataProviderConfigs = _.cloneDeep(this.state.providerConfig);
         let { query } = dataProviderConfigs.configs.config.queryData;
+        const tenantId = this.props.dashboard.properties.tenantId || -1234;
         query = query
             .replace('{{from}}', this.state.fromDate)
             .replace('{{to}}', this.state.toDate)
-            .replace('{{now}}', new Date().getTime());
+            .replace('{{now}}', new Date().getTime())
+            .replace('{{tenantId}}', tenantId);
         dataProviderConfigs.configs.config.queryData.query = query;
         super.getWidgetChannelManager()
             .subscribeWidget(this.props.id, this.handleDataReceived, dataProviderConfigs);

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAverageSessionDuration/src/resources/widgetConf.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsAverageSessionDuration/src/resources/widgetConf.json
@@ -14,7 +14,7 @@
         "config": {
           "siddhiApp": "@store(type='rdbms', datasource='IS_ANALYTICS_DB') @primaryKey('meta_tenantId', 'sessionId') @Index('username','userstoreDomain','tenantDomain') define table SessionInformationTable ( meta_tenantId int, sessionId string, startTime string, terminateTime string, endTime string, duration long, isActive bool, username string, userstoreDomain string, remoteIp string, region string, tenantDomain string, serviceProvider string, identityProviders string, rememberMeFlag bool, userAgent string, userStore string, currentTime string, startTimestamp long, renewTimestamp long, terminationTimestamp long, endTimestamp long, timestamp long);",
           "queryData": {
-            "query": "from SessionInformationTable select userStore as username, avg(duration)/1000 as duration GROUP BY username having (startTimestamp >= 0 and startTimestamp <= {{to}}L ) and ((endTimestamp >= {{from}}L and endTimestamp <= {{now}}L) or isActive == true ) order by duration desc"
+            "query": "from SessionInformationTable on (startTimestamp >= 0 and startTimestamp <= {{to}}L) and ((endTimestamp >= {{from}}L and endTimestamp <= {{now}}L) or isActive == true) and meta_tenantId == {{tenantId}} select userStore as username, avg(duration)/1000 as duration group by username order by duration desc"
           },
           "publishingInterval": 60
         }

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSessionCountOverTime/src/IsAnalyticsSessionCountOverTime.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSessionCountOverTime/src/IsAnalyticsSessionCountOverTime.jsx
@@ -115,6 +115,7 @@ class IsAnalyticsSessionCountOverTime extends Widget {
                 default:
                     // This will never hit
             }
+            chartConfig.maxLength = (data.length > 0 ? data.length : 10);
             return { chartConfig };
         });
     }
@@ -132,10 +133,12 @@ class IsAnalyticsSessionCountOverTime extends Widget {
         super.getWidgetChannelManager().unsubscribeWidget(this.props.id);
         const dataProviderConfigs = _.cloneDeep(this.state.providerConfig);
         let { query } = dataProviderConfigs.configs.config.queryData;
+        const tenantId = this.props.dashboard.properties.tenantId || -1234;
         query = query
             .replace('{{per}}', this.state.per)
             .replace('{{from}}', this.state.fromDate)
-            .replace('{{to}}', this.state.toDate);
+            .replace('{{to}}', this.state.toDate)
+            .replace('{{tenantId}}', tenantId);
         dataProviderConfigs.configs.config.queryData.query = query;
         super.getWidgetChannelManager()
             .subscribeWidget(this.props.id, this.handleDataReceived, dataProviderConfigs);

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSessionCountOverTime/src/resources/widgetConf.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsSessionCountOverTime/src/resources/widgetConf.json
@@ -14,7 +14,7 @@
         "config":{
           "siddhiApp":"@App:name('IS_ANALYTICS_SESSION_DATA') @App:description('Receiving Streams from IS and executing and analyzing statistics for session') define stream SessionStatisticsPerSecond (meta_tenantId int, activeSessionCount long, newSessionCount long, terminatedSessionCount long, timestamp long); @Store(type=\"rdbms\",datasource=\"IS_ANALYTICS_DB\") define aggregation SessionAggregation from SessionStatisticsPerSecond select  meta_tenantId, activeSessionCount, sum(newSessionCount) as newSessionCount, sum(terminatedSessionCount) as terminatedSessionCount group by meta_tenantId aggregate by timestamp every sec...year;",
           "queryData":{
-            "query":"from SessionAggregation within {{from}}L, {{to}}L per \"{{per}}s\" select AGG_TIMESTAMP as timestamp, activeSessionCount as Active, newSessionCount as New, terminatedSessionCount as Terminated"
+            "query":"from SessionAggregation on meta_tenantId=={{tenantId}} within {{from}}L, {{to}}L per \"{{per}}s\" select AGG_TIMESTAMP as timestamp, activeSessionCount as Active, newSessionCount as New, terminatedSessionCount as Terminated"
           },
           "publishingInterval": 60
         }

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsTopLongestSession/src/IsAnalyticsTopLongestSession.jsx
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsTopLongestSession/src/IsAnalyticsTopLongestSession.jsx
@@ -124,10 +124,12 @@ class IsAnalyticsTopLongestSession extends Widget {
         super.getWidgetChannelManager().unsubscribeWidget(this.props.id);
         const dataProviderConfigs = _.cloneDeep(this.state.providerConfig);
         let { query } = dataProviderConfigs.configs.config.queryData;
+        const tenantId = this.props.dashboard.properties.tenantId || -1234;
         query = query
             .replace('{{from}}', this.state.fromDate)
             .replace('{{to}}', this.state.toDate)
-            .replace('{{now}}', new Date().getTime());
+            .replace('{{now}}', new Date().getTime())
+            .replace('{{tenantId}}', tenantId);
         dataProviderConfigs.configs.config.queryData.query = query;
         super.getWidgetChannelManager()
             .subscribeWidget(this.props.id, this.handleDataReceived, dataProviderConfigs);

--- a/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsTopLongestSession/src/resources/widgetConf.json
+++ b/components/is-analytics/org.wso2.analytics.solutions.is.analytics/widgets/IsAnalyticsTopLongestSession/src/resources/widgetConf.json
@@ -14,7 +14,7 @@
         "config": {
           "siddhiApp": "@store(type='rdbms', datasource='IS_ANALYTICS_DB') @primaryKey('meta_tenantId', 'sessionId') @Index('username','userstoreDomain','tenantDomain') define table SessionInformationTable ( meta_tenantId int, sessionId string, startTime string, terminateTime string, endTime string, duration long, isActive bool, username string, userstoreDomain string, remoteIp string, region string, tenantDomain string, serviceProvider string, identityProviders string, rememberMeFlag bool, userAgent string, userStore string, currentTime string, startTimestamp long, renewTimestamp long, terminationTimestamp long, endTimestamp long, timestamp long);",
           "queryData": {
-            "query": "from SessionInformationTable select sessionId, userStore as username, duration/1000 as duration having (startTimestamp >= 0 AND startTimestamp <= {{to}}L ) AND ((endTimestamp >= {{from}}L AND endTimestamp <= {{now}}L) OR isActive == true) order by duration desc"
+            "query": "from SessionInformationTable on (startTimestamp >= 0 and startTimestamp <= {{to}}L) and ((endTimestamp >= {{from}}L AND endTimestamp <= {{now}}L) or isActive == true) and meta_tenantId == {{tenantId}} select sessionId, userStore as username, duration/1000 as duration order by duration desc"
           },
           "publishingInterval": 60
         }


### PR DESCRIPTION
## Purpose
This PR fixes the following issues in the IS-Analytics dashboard.

- Invalid granularity is selected when selecting 3/6 months in the date range picker.
- No data in Top longest session and average session duration widgets.
- No tenant filtration in widgets
- Missing data in charts.

To fix the data not showing issue in the average session duration widget in MySQL, follow the steps mentioned below.

1. Log on the MySQL console and run the following command to remove `ONLY_FULL_GROUP_BY` from `sql_mode`.

```sql
SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode, 'ONLY_FULL_GROUP_BY,', ''));
```
2. Re-login to the MySQL console.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes